### PR TITLE
Corrupted shapefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 .env
+data/shapefiles/

--- a/src/routes/maps.ts
+++ b/src/routes/maps.ts
@@ -517,14 +517,15 @@ async function downloadMap(request: PublicMapRequest, h: FileResponseToolkit): P
     const { mapId } = request.params;
     const { user_id } = request.auth.artifacts;
 
-    const userMap = await Model.UserMap.findOne({
+    const hasAccess = await Model.UserMap.findOne({
         where: {
             user_id,
             map_id: mapId
         }
     });
-    if (!userMap)
-        return h.response({ success: false, message: "User account doesn't have read access to that map" });
+    if (!hasAccess) {
+        return h.response("Unauthorised!").code(403);
+    }
 
     const map = await Model.Map.findOne({
         where: {


### PR DESCRIPTION
**What? Why?**
Closes https://github.com/DigitalCommons/land-explorer-front-end/issues/105

The Shapefile download was not creating a valid file download. This was due to the backend library geojson2shp throwing a "ENOENT: no such file or directory" error when trying to write a shapefile ZIP to a specified file path. I couldn't find any bug reported about this, but found that it worked when specifying a file stream instead of a path, which is what we now do.

**What should we test?**
Create some markers, lines and polygons and save the map.
Click Share -> Export -> Shapefile
Test importing the Shapefile ZIP on an external tool e.g. https://mapshaper.org/ and check that this works ok, with all shapes showing as expected
Repeat for the same map and check that the second ZIP works too