### PR TITLE
Don't try to save data field to user map table

### DIFF
--- a/src/routes/maps.ts
+++ b/src/routes/maps.ts
@@ -155,7 +155,6 @@ async function setMapAsViewed(request: Request, h: ResponseToolkit, d: any): Pro
         await Model.UserMap.update(
             {
                 viewed: 1,
-                data: payload.data,
             },
             {
                 where: {


### PR DESCRIPTION
**What? Why?**
Closes https://github.com/DigitalCommons/land-explorer-front-end/issues/119

The 400 error was being thrown by failed validation, which was already fixed by https://github.com/DigitalCommons/land-explorer-back-end/commit/da4179eacd4e75cabf3455ec543533801a2c37b7. In this PR, I'm just removing an uncessary line of code, since the user map table doesn't have a data column.

**What should we test?**
Create and save a map.
Set the value of the viewed field in the user_map table to b'0' (i.e. not viewed) by editing MySql table.
Open the saved map again
Check that we received a 200 OK (in Chrome inspect -> network) and the viewed field was changed to 1
