### PR TITLE
Specify latin1 encoding for shapefiles

### DIFF
--- a/seeders/9_test_map_membership.js
+++ b/seeders/9_test_map_membership.js
@@ -17,7 +17,7 @@ module.exports = {
         //the data field doesn't contain the drawn objects, meaning seeding requires a save for the seeded map items to show up
         const testMapId = await queryInterface.bulkInsert('map', [{
             name: "Test Map",
-            data: `{ "map": { "zoom": [7.098862221873304], "lngLat": [-1.4231817045257742, 52.472531034277125], "searchMarker": null, "marker": [-0.2416815, 51.5285582], "gettingLocation": false, "currentLocation": null, "movingMethod": "flyTo", "name": "Test Map" }, "drawings": { "polygons": [], "activePolygon": null, "polygonCount": 1, "lineCount": 1, "loadingDrawings": false }, "markers": { "searchMarker": [-0.2416815, 51.5285582], "currentMarker": null, "id": 1, "markers": [] }, "mapLayers": { "landDataLayers": [], "myDataLayers": [] }, "version": "1.1", "name": "Test Map", "markersInDB": true }`,
+            data: `{ "map": { "zoom": [7.098862221873304], "lngLat": [-1.4231817045257742, 52.472531034277125], "searchMarker": null, "marker": [-0.2416815, 51.5285582], "gettingLocation": false, "currentLocation": null, "movingMethod": "flyTo", "name": "Test Map" }, "drawings": { "polygons": [], "activePolygon": null, "polygonCount": 1, "lineCount": 1, "loadingDrawings": false }, "markers": { "searchMarker": [-0.2416815, 51.5285582], "currentMarker": null, "id": 1, "markers": [] }, "mapLayers": { "landDataLayers": [], "myDataLayers": [] }, "version": "1.1", "name": "Test Map", "drawingsInDB": true }`,
             deleted: 0,
             created_date: new Date(),
             last_modified: new Date()

--- a/src/routes/maps.ts
+++ b/src/routes/maps.ts
@@ -747,7 +747,8 @@ async function downloadMap(request: PublicMapRequest, h: FileResponseToolkit): P
     const outStream = fs.createWriteStream(shapeFileLocation);
     const convertOptions = {
         layer: 'land-explorer-layer',
-        targetCrs: 2154
+        targetCrs: 2154,
+        encoding: 'latin1'
     };
     // create a new shapefile in the shape file location
     await convert(features, outStream, convertOptions);


### PR DESCRIPTION
**What? Why?**
Closes https://github.com/DigitalCommons/land-explorer-front-end/issues/105

The Shapefile download was fixed by https://github.com/DigitalCommons/land-explorer-back-end/pull/16 and https://github.com/DigitalCommons/land-explorer-back-end/pull/24.

But when there are non ASCII characters in titles or descriptions, the encoding needs to be specified when producing the shapefile. This change specifies latin1 encoding (same as database).

**What should we test?**
Save a map with RGS orchards layer enabled (which contains a marker with weird title "
Ein Berllan â€“ Our Orchard, University Hospital Llandough")
Click Share -> Export -> Shapefile
Test importing the Shapefile ZIP on an external tool e.g. https://mapshaper.org/ and check that this works ok, with all shapes showing as expected