### PR TITLE
LX-181 Fix the link in the password reset email

### DIFF
--- a/src/queries/mails.ts
+++ b/src/queries/mails.ts
@@ -1,11 +1,8 @@
-const { QueryTypes } = require('sequelize');
-const { sequelize, User, Map, UserMap, PendingUserMap } = require('./database');
-const bcrypt = require('bcrypt');
+import sgMail from "@sendgrid/mail";
 
-const sgMail = require("@sendgrid/mail");
-sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+sgMail.setApiKey(process.env.SENDGRID_API_KEY || '');
 
-const authRoute = "auth/";
+const authRoute = "/auth/";
 let sender = "landexplorer@digitalcommons.coop";
 let senderName = "Land Explorer";
 

--- a/src/routes/database.ts
+++ b/src/routes/database.ts
@@ -39,7 +39,7 @@ type RegisterRequest = Request & {
 };
 
 async function registerUser(request: RegisterRequest, h: ResponseToolkit): Promise<ResponseObject> {
-    const originDomain = request.headers.referer;
+    const originDomain = request.info.host;
 
     let validation = new Validation();
     await validation.validateUserRegister(request.payload);
@@ -279,7 +279,7 @@ async function changePassword(request: Request, h: ResponseToolkit, d: any): Pro
  * @returns 
  */
 async function resetPassword(request: Request, h: ResponseToolkit, d: any): Promise<ResponseObject> {
-    const originDomain = request.headers.referer;
+    const originDomain = request.info.host;
 
     let validation = new Validation();
     await validation.validateResetPassword(request.payload);
@@ -298,6 +298,8 @@ async function resetPassword(request: Request, h: ResponseToolkit, d: any): Prom
         });
 
         if (!user) {
+            // TODO: change this behaviour. We shouldn't spam an email that doesn't have an account...
+
             //If this email is not an user, notify them accordingly 
             mailer.resetPasswordNotFound(payload.username);
             return h.response().code(200);

--- a/src/routes/maps.ts
+++ b/src/routes/maps.ts
@@ -224,7 +224,7 @@ async function setMapAsViewed(request: Request, h: ResponseToolkit, d: any): Pro
  * @returns 
  */
 async function mapSharing(request: Request, h: ResponseToolkit, d: any): Promise<ResponseObject> {
-    const originDomain = request.headers.referer;
+    const originDomain = request.info.host;
 
     const validation = new Validation();
     await validation.validateShareMap(request.payload);


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/DigitalCommons/land-explorer-front-end/issues/181

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Triggering a reset password sends an email that directs to a bad link: https://app.testing-lx.com/auth/reset-passwordauth/

A bad link is also sent when a map is shared via email, or when a user registers an account. This changes fixes that.

#### What should we test?
<!-- List which features should be tested and how.
     This can be similar to the Steps to Reproduce in the issue.
     Also think of other parts of the app which could be affected
     by your change. -->

Logout and hit Reset Password
Enter email
Receive email and follow the link to the login page

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->


#### Documentation updates
<!-- Are there any wiki pages that need updating after merging this 
     PR? List them here or remove this section. -->
