### PR TITLE
LX-161 Add seed storage to prevent duplication of data

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -5,10 +5,12 @@ module.exports = {
     database: process.env.DATABASE_NAME,
     host: process.env.DATABASE_HOST,
     dialect: 'mysql',
+    seederStorage: 'sequelize',
     logging: false,
   },
   test: {
     dialect: 'sqlite::memory:',
+    seederStorage: 'sequelize',
     logging: false,
   },
   production: {
@@ -17,6 +19,7 @@ module.exports = {
     database: process.env.DATABASE_NAME,
     host: process.env.DATABASE_HOST,
     dialect: 'mysql',
+    seederStorage: 'sequelize',
     logging: false,
     pool: {
       max: 5,


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/DigitalCommons/land-explorer-front-end/issues/161

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

Enables seed storage, like migrations already are by default, so that we don't re-run the same seeding scripts.

#### Dev test

Check that running npx sequelize-cli db:seed:all doesn't run seeders more than once

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->
Before deployment to staging and production, we can remove data that has been duplicated and then let it seed one last time. There are a load of unnecessary entries in the database that have been duplicated every time we deployed to staging or production.

I (Rohit) am happy to do this since I've thought a bit about what needs removing and how to do it safely.

After deployment, we can get rid of the checks that sometimes happen in the seeding scripts e.g. "if (publicUserExists)", since they're no longer necessary and might be a bit confusing.