### PR TITLE
LX-195 Look for username in request.auth.credentials consistently

### DIFF
--- a/src/routes/maps.ts
+++ b/src/routes/maps.ts
@@ -188,7 +188,7 @@ async function saveMapZoom(request: SaveMapZoomRequest, h: ResponseToolkit, d: a
         where: {
             map_id: eid,
             access: UserMapAccess.Readwrite,
-            user_id: request.auth.artifacts.user_id
+            user_id: request.auth.credentials.user_id
         }
     });
     if (hasAccess === null) {
@@ -215,7 +215,7 @@ async function saveMapLngLat(request: SaveMapLngLatRequest, h: ResponseToolkit, 
         where: {
             map_id: eid,
             access: UserMapAccess.Readwrite,
-            user_id: request.auth.artifacts.user_id
+            user_id: request.auth.credentials.user_id
         }
     });
     if (hasAccess === null) {


### PR DESCRIPTION
Fixes https://github.com/digitalcommons/land-explorer-front-end/issues/195

There was a merge conflict. We now store username in the HAPI request.auth.credentials object, rather than request.auth.artifacts, but this change wasn't made to 2 new APIs for storing zoom + position of map.

To test:
Save a new map and then drag the position/zoom in and out.