### PR TITLE
Added hex_colour column to data_groups table

### DIFF
--- a/migrations/20220419172600-create-data_groups.js
+++ b/migrations/20220419172600-create-data_groups.js
@@ -6,7 +6,6 @@ module.exports = {
       `CREATE TABLE data_groups (
                 iddata_groups INT NOT NULL AUTO_INCREMENT,
                 title VARCHAR(45) NOT NULL,
-                hex_colour VARCHAR(7) DEFAULT NULL,
                 PRIMARY KEY (iddata_groups)
             ) ENGINE=InnoDB DEFAULT CHARSET=latin1`
     );

--- a/migrations/20220419172600-create-data_groups.js
+++ b/migrations/20220419172600-create-data_groups.js
@@ -1,18 +1,17 @@
-'use strict';
+"use strict";
 
 module.exports = {
-    async up(queryInterface, Sequelize) {
-
-        await queryInterface.sequelize.query(
-            `CREATE TABLE data_groups (
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `CREATE TABLE data_groups (
                 iddata_groups INT NOT NULL AUTO_INCREMENT,
                 title VARCHAR(45) NOT NULL,
+                hex_colour VARCHAR(7) DEFAULT NULL,
                 PRIMARY KEY (iddata_groups)
             ) ENGINE=InnoDB DEFAULT CHARSET=latin1`
-        );
-
-    },
-    async down(queryInterface, Sequelize) {
-        await queryInterface.sequelize.query(`DROP TABLE data_groups`);
-    }
+    );
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`DROP TABLE data_groups`);
+  },
 };

--- a/migrations/2024041716570000-add-data_groups-hex_colour.js
+++ b/migrations/2024041716570000-add-data_groups-hex_colour.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE data_groups 
+            ADD hex_colour VARCHAR(7) DEFAULT NULL;`
+    );
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE data_groups 
+            DROP hex_colour;`
+    );
+  },
+};

--- a/src/queries/database.ts
+++ b/src/queries/database.ts
@@ -123,6 +123,7 @@ const DataGroupModel = sequelize.define(
       primaryKey: true,
     },
     title: { type: DataTypes.STRING },
+    hex_colour: { type: DataTypes.STRING },
   },
   {
     tableName: "data_groups",


### PR DESCRIPTION
#### What? Why?

Closes #313

Added hex_colour column to data_groups table to facilitate custom colour for dataGroups.

![image](https://github.com/DigitalCommons/land-explorer-back-end/assets/22494228/9eb2cc75-f3a1-4bd6-b0f7-671d3ffe0fec)

#### What should we test?
Test in conjunction with https://github.com/DigitalCommons/land-explorer-front-end/pull/315

Expected functionality as below. Once the selected Social Farms and Gardens dataGroup is toggled, markers, pop-up, lines and polys should display in a custom colour (once the colours are added to the requisite db table column).

![image](https://github.com/DigitalCommons/land-explorer-back-end/assets/22494228/7347cc12-1910-4ebe-86a3-16d61ed6f9b3)