### PR TITLE
INSPIRE pipeline: Allow super users to view pending polygons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,11 @@
 {
-    "files.insertFinalNewline": true,
-    "mochaExplorer.envPath": ".env.test",
-    "mochaExplorer.require": "ts-node/register",
-    "mochaExplorer.configFile": ".mocharc.json",
-    "mocha-snippets.quote-type": "double",
-    "mocha-snippets.glob": "**/*.test.ts",
+  "files.insertFinalNewline": true,
+  "mochaExplorer.envPath": ".env.test",
+  "mochaExplorer.require": "ts-node/register",
+  "mochaExplorer.configFile": ".mocharc.json",
+  "mocha-snippets.quote-type": "double",
+  "mocha-snippets.glob": "**/*.test.ts",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "modifications",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -220,7 +220,35 @@ export const getPolygons = async (
     }
   );
 
-  return boundaryResponse.data[0];
+  return boundaryResponse.data;
+};
+
+/**
+ * Return the pending geojson polygons of land ownership within a given bounding box area. These are
+ * the new boundaries from the latest INSPIRE pipeline run that are waiting to be permanently saved.
+ */
+export const getPendingPolygons = async (
+  sw_lng: number,
+  sw_lat: number,
+  ne_lng: number,
+  ne_lat: number,
+  acceptedOnly: boolean = false
+) => {
+  const boundaryResponse = await axios.get(
+    `${process.env.BOUNDARY_SERVICE_URL}/pending/boundaries`,
+    {
+      params: {
+        sw_lat,
+        sw_lng,
+        ne_lat,
+        ne_lng,
+        acceptedOnly,
+        secret: process.env.BOUNDARY_SERVICE_SECRET,
+      },
+    }
+  );
+
+  return boundaryResponse.data;
 };
 
 export const searchOwner = async (proprietorName: string) => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -293,32 +293,7 @@ export class Validation {
     return this;
   }
 
-  /**
-   * Validate polygon
-   *
-   * @param data
-   * @returns
-   */
-  async validateLandOwnershipPolygonRequest(data: any) {
-    // sw_lng, sw_lat, ne_lng, ne_lat required
-
-    if (Joi.number().validate(data?.sw_lng, { presence: "required" }).error) {
-      this.addErrorMessage("sw_lng", "The sw_lng field is required.");
-    }
-    if (Joi.number().validate(data?.sw_lat, { presence: "required" }).error) {
-      this.addErrorMessage("sw_lat", "The sw_lat field is required.");
-    }
-    if (Joi.number().validate(data?.ne_lng, { presence: "required" }).error) {
-      this.addErrorMessage("ne_lng", "The ne_lng field is required.");
-    }
-    if (Joi.number().validate(data?.ne_lat, { presence: "required" }).error) {
-      this.addErrorMessage("ne_lat", "The ne_lat field is required.");
-    }
-
-    return this;
-  }
-
-  /**
+  /**s
    *
    * @param key
    * @param message

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -293,12 +293,6 @@ export class Validation {
     return this;
   }
 
-  /**s
-   *
-   * @param key
-   * @param message
-   * @returns
-   */
   addErrorMessage(key: string, message: string) {
     if (this.errors.hasOwnProperty(key)) {
       this.errors[key].push(message);


### PR DESCRIPTION
#### What? Why?

- Extends the `/api/ownership` route to allow super users to get pending polygons from the PBS, which have been downloaded from INSPIRE data and pending analysis.
- Removes double nesting of array from the response, to align with PBS API changes.


#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to 
     ensure the PR behaves correctly? -->
When this is deployed to `main`, it must be deployed alongside the PBS changes in https://github.com/DigitalCommons/property-boundaries-service/pull/15 to ensure compatibility
