### PR TITLE
LX-67 Key properties by title_no instead of poly_id

### DIFF
--- a/src/queries/query.test.ts
+++ b/src/queries/query.test.ts
@@ -375,3 +375,201 @@ describe("findAllDataGroupContentForUser", () => {
     }
   );
 });
+
+describe("groupPolysByTitleNo", () => {
+  context("Simple case", () => {
+    it("returns polygons grouped by title_no", () => {
+      const polygons = [
+        {
+          title_no: "NN123456",
+          poly_id: "1",
+
+          geom: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [1, 0],
+                [0, 1],
+                [0, 0],
+              ],
+            ],
+          },
+        },
+        {
+          title_no: "NN123456",
+          poly_id: "2",
+          geom: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [2, 2],
+                [2, 3],
+                [3, 2],
+                [2, 2],
+              ],
+            ],
+          },
+        },
+        {
+          title_no: "PQ809176",
+          poly_id: "3",
+          geom: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [3, 3],
+                [3, 4],
+                [4, 3],
+                [3, 3],
+              ],
+            ],
+          },
+        },
+      ];
+      const result = query.groupPolysByTitleNo(polygons);
+      expect(result).to.deep.equal({
+        NN123456: {
+          title_no: "NN123456",
+          polygons: [
+            {
+              poly_id: "1",
+              geom: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [0, 0],
+                    [1, 0],
+                    [0, 1],
+                    [0, 0],
+                  ],
+                ],
+              },
+            },
+            {
+              poly_id: "2",
+              geom: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [2, 2],
+                    [2, 3],
+                    [3, 2],
+                    [2, 2],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+        PQ809176: {
+          title_no: "PQ809176",
+          polygons: [
+            {
+              poly_id: "3",
+              geom: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [3, 3],
+                    [3, 4],
+                    [4, 3],
+                    [3, 3],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  context("There are polygons with null/empty title_no", () => {
+    it("polys with null/empty title_no get a dummy title_no of the form 'unknown_<poly_id>'", () => {
+      const polygons = [
+        {
+          title_no: null,
+          poly_id: "1",
+          geom: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0, 0],
+              ],
+            ],
+          },
+        },
+        {
+          title_no: "",
+          poly_id: "2",
+          geom: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [2, 2],
+                [3, 2],
+                [3, 3],
+                [2, 3],
+                [2, 2],
+              ],
+            ],
+          },
+        },
+      ];
+      const result = query.groupPolysByTitleNo(polygons);
+      expect(result).to.deep.equal({
+        unknown_1: {
+          title_no: "unknown_1",
+          polygons: [
+            {
+              poly_id: "1",
+              geom: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [0, 0],
+                    [1, 0],
+                    [1, 1],
+                    [0, 1],
+                    [0, 0],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+        unknown_2: {
+          title_no: "unknown_2",
+          polygons: [
+            {
+              poly_id: "2",
+              geom: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [2, 2],
+                    [3, 2],
+                    [3, 3],
+                    [2, 3],
+                    [2, 2],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  it("should handle an empty array", () => {
+    const polygons = [];
+    const result = query.groupPolysByTitleNo(polygons);
+    expect(result).to.deep.equal({});
+  });
+});

--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -201,7 +201,35 @@ export const checkAndReturnUser = async (
 };
 
 /**
- * Return the land ownership geojson polygons within a given bounding box area
+ * Group land ownership polygons by their title_no field. Polygons with null/empty title_no get
+ * a dummy title_no of the form "unknown_<poly_id>".
+ */
+export const groupPolysByTitleNo = (
+  polygons: any[]
+): { [title_no: string]: { polygons: any[], [key: string]: any } } => { 
+  const groupedPolygons: { [title_no: string]: { polygons: any[], [key: string]: any } } = {};
+
+  polygons.forEach((polygon: any) => {
+
+    if (!polygon.title_no) {
+      // Create dummy title_no
+      polygon.title_no = `unknown_${polygon.poly_id}`;
+    }
+
+    const { poly_id, geom, ...titleProperties } = polygon;
+
+    if (!groupedPolygons[polygon.title_no]) {
+      groupedPolygons[polygon.title_no] = { ...titleProperties, polygons: [] };
+    }
+    groupedPolygons[polygon.title_no].polygons.push({poly_id, geom});
+  });
+
+  return groupedPolygons;
+};
+
+/**
+ * Return an array of land ownership titles, each mapping to an array of geojson polygons, within a
+ * given bounding box area.
  *
  * @param sw_lng longitude of south-west corner
  * @param sw_lat latitude of south-west corner
@@ -212,14 +240,14 @@ export const checkAndReturnUser = async (
  * @param acceptedOnly only matters if type is "pending". If true, only return pending polys marked
  * as accepted
  */
-export const getPolygons = async (
+export const getLandOwnershipTitlesInBbox = async (
   sw_lng: number,
   sw_lat: number,
   ne_lng: number,
   ne_lat: number,
   type?: string,
   acceptedOnly?: boolean
-): Promise<any[]> => {
+): Promise<{ [title_no: string]: { polygons: any[]; [key: string]: any } }> => {
   const boundaryResponse = await axios.get(
     `${process.env.BOUNDARY_SERVICE_URL}/boundaries`,
     {
@@ -235,10 +263,18 @@ export const getPolygons = async (
     }
   );
 
-  return boundaryResponse.data;
+  const polygons = boundaryResponse.data;
+
+  return groupPolysByTitleNo(polygons);
 };
 
-export const searchOwner = async (proprietorName: string) => {
+/**
+ * Return an array of land ownership titles, each mapping to an array of geojson polygons, that are
+ * owned (or jointly owned) by the given proprietor.
+ */
+export const searchOwner = async (
+  proprietorName: string
+): Promise<{ [title_no: string]: { polygons: any[]; [key: string]: any } }> => {
   const boundaryResponse = await axios.get(
     `${process.env.BOUNDARY_SERVICE_URL}/search`,
     {
@@ -249,7 +285,9 @@ export const searchOwner = async (proprietorName: string) => {
     }
   );
 
-  return boundaryResponse.data;
+  const polygons = boundaryResponse.data;
+
+  return groupPolysByTitleNo(polygons);
 };
 
 export const findAllDataGroupContentForUser = async (userId: number) => {

--- a/src/routes/maps.test.ts
+++ b/src/routes/maps.test.ts
@@ -191,7 +191,7 @@ describe("GET /api/ownership", () => {
 
   beforeEach(async () => {
     server = await init();
-    sandbox.replace(query, "getPolygons", fake.resolves([]));
+    sandbox.replace(query, "getLandOwnershipTitlesInBbox", fake.resolves([]));
     getLandOwnershipPolygonsRequest.url =
       "/api/ownership?sw_lng=0.3&sw_lat=53.2&ne_lng=0.4&ne_lat=53.3";
   });

--- a/src/routes/maps.ts
+++ b/src/routes/maps.ts
@@ -10,7 +10,7 @@ import { Validation } from "../validation";
 import {
   createPublicMapView,
   getGeoJsonFeaturesForMap,
-  getPolygons,
+  getLandOwnershipTitlesInBbox,
   searchOwner,
 } from "../queries/query";
 import {
@@ -760,35 +760,52 @@ type GetLandOwnershipPolygonsRequest = Request & {
 };
 
 /**
- * Get the geojson polygons of land ownership within a given bounding box area
+ * Get the land ownership titles within a given bounding box area, each title being made up of an
+ * array of geojson polygons.
  */
-async function getLandOwnershipPolygons(
+async function getLandOwnershipTitles(
   request: GetLandOwnershipPolygonsRequest,
   h: ResponseToolkit,
   d: any
 ): Promise<ResponseObject> {
   const { sw_lng, sw_lat, ne_lng, ne_lat, type, acceptedOnly } = request.query;
   const { user_id } = request.auth.credentials;
-  let polygons;
+  let titles;
 
   switch (type) {
     case "all":
     case undefined:
     case "localAuthority":
     case "churchOfEngland":
-      polygons = await getPolygons(sw_lng, sw_lat, ne_lng, ne_lat, type);
-      return h.response(polygons).code(200);
-    case "unregistered":
-      polygons = (await getPolygons(sw_lng, sw_lat, ne_lng, ne_lat, type)).map(
-        (polygon) => ({
-          ...polygon,
-          // Add tenure field which is used by front-end
-          tenure: "unregistered",
-          // Add U prefix to ID to avoid conflicts with actual poly_ids
-          poly_id: `U${polygon.poly_id}`,
-        })
+      titles = await getLandOwnershipTitlesInBbox(
+        sw_lng,
+        sw_lat,
+        ne_lng,
+        ne_lat,
+        type
       );
-      return h.response(polygons).code(200);
+      return h.response(titles).code(200);
+    case "unregistered":
+      titles = Object.fromEntries(
+        Object.entries(
+          await getLandOwnershipTitlesInBbox(
+            sw_lng,
+            sw_lat,
+            ne_lng,
+            ne_lat,
+            type
+          )
+        ).map(([title_no, props]) => [
+          title_no.replace("unknown_", "U-"), // Use U- prefix to avoid conflicts with actual title_nos
+          {
+            ...props,
+            title_no: title_no.replace("unknown_", "U-"),
+            // Add tenure field which is used by front-end
+            tenure: "unregistered",
+          },
+        ])
+      );
+      return h.response(titles).code(200);
     case "pending":
       // These are the new boundaries from the latest INSPIRE pipeline run that are waiting to be
       // permanently saved. Only super users should be able to view pending polygons.
@@ -802,19 +819,32 @@ async function getLandOwnershipPolygons(
         return h.response("Unauthorised!").code(403);
       }
 
-      polygons = await getPolygons(
-        sw_lng,
-        sw_lat,
-        ne_lng,
-        ne_lat,
-        type,
-        acceptedOnly
+      titles = Object.fromEntries(
+        Object.entries(
+          await getLandOwnershipTitlesInBbox(
+            sw_lng,
+            sw_lat,
+            ne_lng,
+            ne_lat,
+            type,
+            acceptedOnly
+          )
+        ).map(([title_no, props]) => [
+          // Use "pending_" prefix in title_nos and also add to poly_ids to avoid conflicts with
+          // normal polygons
+          title_no.replace("unknown_", "pending_"),
+          {
+            ...props,
+            title_no: title_no.replace("unknown_", "pending_"),
+            polygons: props.polygons.map((poly) => ({
+              ...poly,
+              poly_id: `pending_${poly.poly_id}`,
+            })),
+          },
+        ])
       );
-      // Add "-pending" to the end of each poly_id to avoid id conflicts with normal polygons
-      polygons.forEach((poly) => {
-        poly.poly_id = `${poly.poly_id}-pending`;
-      });
-      return h.response(polygons).code(200);
+
+      return h.response(titles).code(200);
     default:
       return h.response("unknown ownership type").code(400);
   }
@@ -826,9 +856,9 @@ async function searchOwnership(
 ): Promise<ResponseObject> {
   const { proprietorName } = request.query;
 
-  const polygonsAndOwnerships = await searchOwner(proprietorName);
+  const titles = await searchOwner(proprietorName);
 
-  return h.response(polygonsAndOwnerships).code(200);
+  return h.response(titles).code(200);
 }
 
 type PublicMapRequest = Request & {
@@ -988,7 +1018,7 @@ export const mapRoutes: ServerRoute[] = [
   // Returns a list of all maps that the user has access to
   { method: "GET", path: "/api/user/maps", handler: getUserMaps },
   // Get the geojson polygons of land ownership within a given bounding box area
-  { method: "GET", path: "/api/ownership", handler: getLandOwnershipPolygons },
+  { method: "GET", path: "/api/ownership", handler: getLandOwnershipTitles },
   // search the public ownership information
   { method: "GET", path: "/api/search", handler: searchOwnership },
   // Get a public map


### PR DESCRIPTION
#### What? Why?

Fixes #67 

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

We now display properties by title number in the UI, but in the business logic, we're still keying properties by their poly_id in Redux and the BE.

This PR changes this, so we deal with titles, where each title has an array of `polygons` which correspond to individual ownership polygons, each with their own poly_id.

#### Code-specific details (for Reviewer)

<!-- Any details to help the Reviewer to understand your code changes
     e.g. files to pay special attention to, the structure of the commits  -->
It makes sense for the Property Boundaries Service to still deal with poly_ids since this is what it uses for the pipelines and new INSPIRE IDs don't actually have title_nos.

Therefore the main change to the BE is that, after getting the list of polygons, it groups them by title_no and massages teh data into the right format for the FE.

The FE can then store the properties like this, as a map of title_no -> title, where each title has an array of `polygons`.

##### Use of AI

I used Cursor during this work.

On the BE, I first tried seeing how well it would perform if I asked in the sidebar chat to key by title_no instead of poly_id (with a paragraph of helpful context). This didn't give a good result so I had to undo it all. Cursor was however useful when I gave it small compartmentalised tasks, such as writing the groupPolysByTitleNo function, which is did pretty well in it's first shot, then I refined it slightly. I found that for the UTs, it wasn't great when asking the sidebar chat to do them from scratch. But if I wrote my own testcase descriptions, the autocomplete function did a pretty good job at filling it out, then I used the inline chat to refine things + a bit of manual editing. After there were a few good tests for the function, I was then able to ask the inline chat if it could think of any other scenarios to test and it came up with 1 good test, 1 pointless one.

For the FE, the sidebar chat was generally poor and I didn't use any of its results. I think this is because the FE codebase is a bit less logic-based and also not in TS. It was however useful for small autocomplete suggestions e.g. when changing a file to use title_nos, after editing one instance in the file, it sped up making the same change throughout the file by clicking Tab (similar to what Copilot also does but a bit more aggressively).

#### Checklist

- No docs needed
- [x] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

<!-- List which features should be tested and how.
     Also think of other parts of the app which could be affected
     by your change. -->

- Do some general smoke testing of all the different ownership layers & backsearch to check that they still work as before
- Test some titles where there are multiple linked polygons.
   - Search for Woodend, West Northamptonshire
   - Several properties in this area (e.g. the farmland slightly east of Woodend) have multiple linked inspire polys

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->
