### PR TITLE
add possible social housing to examples

### DIFF
--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -308,7 +308,7 @@ export const groupPolysByTitleNo = (
  * @param ne_lng longitude of north-east corner
  * @param ne_lat latitude of north-east corner
  * @param type type of ownership to return, one of "all" (default), "localAuthority",
- * "churchOfEngland", "pending" or "unregistered".
+ * "churchOfEngland", "socialHousing" "pending" or "unregistered".
  * @param acceptedOnly only matters if type is "pending". If true, only return pending polys marked
  * as accepted
  */

--- a/src/routes/map.ts
+++ b/src/routes/map.ts
@@ -716,7 +716,7 @@ type GetLandOwnershipPolygonsRequest = LoggedInRequest & {
     ne_lat: number;
     /**
      * The type of ownership to return, one of "all", "localAuthority", "churchOfEngland",
-     * "pending", or "unregistered". The latter is regions of land that have no registered
+     * "socialHousing", "pending", or "unregistered". The latter is regions of land that have no registered
      * ownership.
      */
     type?: string;


### PR DESCRIPTION
#### What? Why?

Fixes [#402](https://github.com/DigitalCommons/land-explorer-front-end/issues/402)

Adds to list of examples


#### What should we test?

- Turn on social housing when property boundaries has it on

#### Release notes

<!-- Choose a pull request title above which explains your change to a 
     user. The title of the pull request will be included in the release 
     notes. -->


#### Deployment notes

Nothing different
