### PR TITLE
Add the social housing type

### DIFF
--- a/src/routes/map.test.ts
+++ b/src/routes/map.test.ts
@@ -265,7 +265,7 @@ describe("GET /api/ownership", () => {
           id: 1,
           username: "user1@mail.coop",
           is_super_user: 1,
-        })
+        }),
       );
     });
 
@@ -288,6 +288,12 @@ describe("GET /api/ownership", () => {
 
     it("getting churchOfEngland polygons returns status 200", async () => {
       getLandOwnershipPolygonsRequest.url += "&type=churchOfEngland";
+      const res = await server.inject(getLandOwnershipPolygonsRequest);
+      expect(res.statusCode).to.equal(200);
+    });
+
+    it("getting socialHousing polygons returns status 200", async () => {
+      getLandOwnershipPolygonsRequest.url += "&type=socialHousing";
       const res = await server.inject(getLandOwnershipPolygonsRequest);
       expect(res.statusCode).to.equal(200);
     });

--- a/src/routes/map.ts
+++ b/src/routes/map.ts
@@ -745,12 +745,13 @@ async function getLandOwnershipTitles(
     case undefined:
     case "localAuthority":
     case "churchOfEngland":
+    case "socialHousing":
       titles = await getLandOwnershipTitlesInBbox(
         sw_lng,
         sw_lat,
         ne_lng,
         ne_lat,
-        type
+        type,
       );
       return h.response(titles).code(200);
     case "unregistered":
@@ -761,8 +762,8 @@ async function getLandOwnershipTitles(
             sw_lat,
             ne_lng,
             ne_lat,
-            type
-          )
+            type,
+          ),
         ).map(([title_no, props]) => [
           title_no.replace("unknown_", "U-"), // Use U- prefix to avoid conflicts with actual title_nos
           {
@@ -771,7 +772,7 @@ async function getLandOwnershipTitles(
             // Add tenure field which is used by front-end
             tenure: "unregistered",
           },
-        ])
+        ]),
       );
       return h.response(titles).code(200);
     case "pending":
@@ -795,8 +796,8 @@ async function getLandOwnershipTitles(
             ne_lng,
             ne_lat,
             type,
-            acceptedOnly
-          )
+            acceptedOnly,
+          ),
         ).map(([title_no, props]) => [
           // Use "pending_" prefix in title_nos and also add to poly_ids to avoid conflicts with
           // normal polygons
@@ -809,7 +810,7 @@ async function getLandOwnershipTitles(
               poly_id: `pending_${poly.poly_id}`,
             })),
           },
-        ])
+        ]),
       );
 
       return h.response(titles).code(200);


### PR DESCRIPTION
#### What? Why?

Fixes [#408](https://github.com/DigitalCommons/land-explorer-front-end/issues/408)

This is needed to pass the request for social housing type ownership data through to the property boundaries service

#### What should we test?
Turn on the social housing layer, data should be returned and displayed in the frontend
