### PR TITLE
Add the proprietors endpoint

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -22,3 +22,4 @@ GLITCHTIP_KEY=
 # For Mixpanel analytics, this token and pepper needs to be set
 MIXPANEL_TOKEN=
 ANALYTICS_PEPPER=test_analytics_pepper
+MEILISEARCH_ENABLED=true

--- a/docs/proprietors-endpoint.md
+++ b/docs/proprietors-endpoint.md
@@ -1,0 +1,60 @@
+# Proprietors Search Endpoint
+
+## Overview
+
+`GET /api/proprietors` allows clients to search for land proprietors by name. It proxies the request to the Property Boundaries Service (PBS) and returns paginated results.
+
+## Request
+
+**Authentication:** Bearer token required (standard JWT auth).
+
+**Query parameters:**
+
+| Parameter    | Type    | Required | Default | Constraints             | Description                        |
+|--------------|---------|----------|---------|-------------------------|------------------------------------|
+| `searchTerm` | string  | Yes      | —       | 1–200 characters        | Partial or full proprietor name    |
+| `page`       | integer | No       | `1`     | min 1                   | Page number                        |
+| `pageSize`   | integer | No       | `10`    | min 1, max 100          | Number of results per page         |
+
+**Example:**
+
+```
+GET /api/proprietors?searchTerm=Acme&page=1&pageSize=10
+```
+
+## Response
+
+**200 OK**
+
+```json
+{
+  "results": [
+    { "id": "abc123", "proprietorName": "Acme Ltd" }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "totalResults": 42
+}
+```
+
+**400 Bad Request** - returned when query validation fails (e.g. missing `searchTerm`, value out of range).
+
+```json
+{ "message": "\"searchTerm\" is required" }
+```
+
+**499** - returned when the client disconnects before the PBS response arrives. The in-flight PBS request is aborted via `AbortController`.
+
+**500 Internal Server Error** - returned on unexpected errors from the PBS.
+
+## Feature flag
+
+Set `MEILISEARCH_ENABLED=true` in your `.env` to enable this endpoint. It is enabled by default in `.env.test`.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| [src/routes/proprietors.ts](../src/routes/proprietors.ts) | Route definition, input validation, client-abort handling |
+| [src/queries/proprietors.ts](../src/queries/proprietors.ts) | `searchProprietors()` - axios call to PBS `/proprietors` |
+| [src/routes/proprietors.test.ts](../src/routes/proprietors.test.ts) | Unit tests |

--- a/src/queries/proprietors.ts
+++ b/src/queries/proprietors.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export type ProprietorSearchResponse = {
-  results: { id: number; proprietorName: string }[];
+  results: { id: string; proprietorName: string }[];
   page: number;
   pageSize: number;
   totalResults: number;

--- a/src/queries/proprietors.ts
+++ b/src/queries/proprietors.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+export type ProprietorSearchResponse = {
+  results: { id: number; proprietorName: string }[];
+  page: number;
+  pageSize: number;
+  totalResults: number;
+};
+
+/**
+ * Search for proprietors by name in the Property Boundaries Service.
+ *
+ * @param searchTerm partial or full proprietor name to search for
+ * @param page page number
+ * @param pageSize number of results per page
+ * @param signal optional AbortSignal to cancel the request
+ */
+export const searchProprietors = async (
+  searchTerm: string,
+  page: number,
+  pageSize: number,
+  signal?: AbortSignal,
+): Promise<ProprietorSearchResponse> => {
+  const response = await axios.get(
+    `${process.env.BOUNDARY_SERVICE_URL}/proprietors`,
+    {
+      params: {
+        searchTerm,
+        page,
+        pageSize,
+        secret: process.env.BOUNDARY_SERVICE_SECRET,
+      },
+      signal,
+    },
+  );
+  return response.data;
+};

--- a/src/routes/proprietors.test.ts
+++ b/src/routes/proprietors.test.ts
@@ -1,0 +1,195 @@
+import { expect } from "chai";
+import { createSandbox, fake } from "sinon";
+import { Server } from "@hapi/hapi";
+import { init } from "../server";
+import { ProprietorSearchResponse } from "../queries/proprietors";
+
+// Dependencies to be stubbed
+const proprietors = require("../queries/proprietors");
+
+const sandbox = createSandbox();
+
+describe.only("GET /api/proprietors", () => {
+  let server: Server;
+
+  const validRequest = {
+    method: "GET",
+    url: "/api/proprietors?searchTerm=Cambridge&page=1&pageSize=10",
+    auth: {
+      strategy: "simple",
+      credentials: {
+        user_id: 123,
+      },
+    },
+  };
+
+  const pbsResponse: ProprietorSearchResponse = {
+    results: [
+      { id: "1", proprietorName: "Cambridge Council" },
+      { id: "2", proprietorName: "Cambridge City Council" },
+    ],
+    page: 1,
+    pageSize: 10,
+    totalResults: 2,
+  };
+
+  beforeEach(async () => {
+    server = await init();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    sandbox.restore();
+  });
+
+  context("valid request", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        proprietors,
+        "searchProprietors",
+        fake.resolves(pbsResponse),
+      );
+    });
+
+    it("returns status 200", async () => {
+      const res = await server.inject(validRequest);
+
+      expect(res.statusCode).to.equal(200);
+    });
+
+    it("returns the PBS response", async () => {
+      const res = await server.inject(validRequest);
+
+      expect(res.result).to.deep.equal(pbsResponse);
+    });
+  });
+
+  context("missing searchTerm", () => {
+    it("returns status 400", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?page=1&pageSize=10",
+      });
+
+      expect(res.statusCode).to.equal(400);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes('"searchTerm" is required');
+    });
+  });
+
+  context("missing page (uses default)", () => {
+    it("returns status 200", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&pageSize=10",
+      });
+
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.have.property("page").that.equal(1); // Default page is 1
+    });
+  });
+
+  context("missing pageSize (uses default)", () => {
+    it("returns status 200", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=1",
+      });
+
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.have.property("pageSize").that.equal(10); // Default pageSize is 10
+    });
+  });
+
+  context("non-integer page", () => {
+    it("returns status 400", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=abc&pageSize=10",
+      });
+
+      expect(res.statusCode).to.equal(400);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes('"page" must be a number');
+    });
+  });
+
+  context("page less than 1", () => {
+    it("returns status 400", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=0&pageSize=10",
+      });
+
+      expect(res.statusCode).to.equal(400);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes('"page" must be greater than or equal to 1');
+    });
+  });
+
+  context("unauthenticated request", () => {
+    it("returns status 401", async () => {
+      const res = await server.inject({
+        method: "GET",
+        url: "/api/proprietors?searchTerm=Cambridge&page=1&pageSize=10",
+      });
+
+      expect(res.statusCode).to.equal(401);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes("Missing authentication");
+    });
+  });
+
+  context("PBS throws an error", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        proprietors,
+        "searchProprietors",
+        fake.rejects(new Error("PBS unavailable")),
+      );
+    });
+
+    it("returns status 500", async () => {
+      const res = await server.inject(validRequest);
+
+      expect(res.statusCode).to.equal(500);
+    });
+  });
+
+  context("client disconnects during request", () => {
+    it("returns status 499", async () => {
+      let capturedRawReq: any;
+
+      server.ext("onPreHandler", (request: any, h: any) => {
+        capturedRawReq = request.raw.req;
+        return h.continue;
+      });
+
+      sandbox.replace(
+        proprietors,
+        "searchProprietors",
+        (
+          _searchTerm: string,
+          _page: number,
+          _pageSize: number,
+          signal?: AbortSignal,
+        ) =>
+          new Promise<never>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => {
+              reject(new Error("Request aborted"));
+            });
+            // Simulate the client closing the connection. setImmediate defers
+            // until after the handler has attached its own "close" listener.
+            setImmediate(() => capturedRawReq.emit("close"));
+          }),
+      );
+
+      const res = await server.inject(validRequest);
+      expect(res.statusCode).to.equal(499);
+    });
+  });
+});

--- a/src/routes/proprietors.test.ts
+++ b/src/routes/proprietors.test.ts
@@ -78,59 +78,66 @@ describe("GET /api/proprietors", () => {
     });
   });
 
-  context("missing page (uses default)", () => {
-    beforeEach(() => {
-      sandbox.replace(
-        proprietors,
-        "searchProprietors",
-        fake.resolves(pbsResponse),
-      );
+    context("empty searchTerm", () => {
+      it("returns status 400", async () => {
+        const res = await server.inject({
+          ...validRequest,
+          url: "/api/proprietors?searchTerm=&page=1&pageSize=10",
+        });
+
+        expect(res.statusCode).to.equal(400);
+        expect(res.result)
+          .to.have.property("message")
+          .that.includes('"searchTerm" is not allowed to be empty');
+      });
     });
 
+    context("searchTerm exceeds maximum length", () => {
+      it("returns status 400", async () => {
+        const longSearchTerm = "a".repeat(201);
+        const res = await server.inject({
+          ...validRequest,
+          url: `/api/proprietors?searchTerm=${longSearchTerm}&page=1&pageSize=10`,
+        });
+
+        expect(res.statusCode).to.equal(400);
+        expect(res.result)
+          .to.have.property("message")
+          .that.includes(
+            '"searchTerm" length must be less than or equal to 200',
+          );
+      });
+    });
+
+  context("missing page (uses default)", () => {
     it("returns status 200", async () => {
+      const stub = fake.resolves(pbsResponse);
+      sandbox.replace(proprietors, "searchProprietors", stub);
+
       const res = await server.inject({
         ...validRequest,
         url: "/api/proprietors?searchTerm=Cambridge&pageSize=10",
       });
 
       expect(res.statusCode).to.equal(200);
+      expect(stub.firstCall.args[1]).to.equal(1); // Verify default page is passed to PBS
       expect(res.result).to.have.property("page").that.equal(1); // Default page is 1
     });
   });
 
-  context("missing pageSize (uses default)", () => {
-    beforeEach(() => {
-      sandbox.replace(
-        proprietors,
-        "searchProprietors",
-        fake.resolves(pbsResponse),
-      );
-    });
+   context("non-integer page", () => {
+     it("returns status 400", async () => {
+       const res = await server.inject({
+         ...validRequest,
+         url: "/api/proprietors?searchTerm=Cambridge&page=abc&pageSize=10",
+       });
 
-    it("returns status 200", async () => {
-      const res = await server.inject({
-        ...validRequest,
-        url: "/api/proprietors?searchTerm=Cambridge&page=1",
-      });
-
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.have.property("pageSize").that.equal(10); // Default pageSize is 10
-    });
-  });
-
-  context("non-integer page", () => {
-    it("returns status 400", async () => {
-      const res = await server.inject({
-        ...validRequest,
-        url: "/api/proprietors?searchTerm=Cambridge&page=abc&pageSize=10",
-      });
-
-      expect(res.statusCode).to.equal(400);
-      expect(res.result)
-        .to.have.property("message")
-        .that.includes('"page" must be a number');
-    });
-  });
+       expect(res.statusCode).to.equal(400);
+       expect(res.result)
+         .to.have.property("message")
+         .that.includes('"page" must be a number');
+     });
+   });
 
   context("page less than 1", () => {
     it("returns status 400", async () => {
@@ -143,6 +150,80 @@ describe("GET /api/proprietors", () => {
       expect(res.result)
         .to.have.property("message")
         .that.includes('"page" must be greater than or equal to 1');
+    });
+  });
+
+  context("missing pageSize (uses default)", () => {
+    it("returns status 200", async () => {
+      const stub = fake.resolves(pbsResponse);
+      sandbox.replace(proprietors, "searchProprietors", stub);
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=1",
+      });
+
+      expect(res.statusCode).to.equal(200);
+      expect(stub.firstCall.args[2]).to.equal(10); // Verify default pageSize is passed to PBS
+      expect(res.result).to.have.property("pageSize").that.equal(10); // Default pageSize is 10
+    });
+  });
+
+  context("non-integer pageSize", () => {
+    it("returns status 400", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=1&pageSize=abc",
+      });
+
+      expect(res.statusCode).to.equal(400);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes('"pageSize" must be a number');
+    });
+  });
+
+  context("pageSize less than 1", () => {
+    it("returns status 400", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=1&pageSize=0",
+      });
+
+      expect(res.statusCode).to.equal(400);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes('"pageSize" must be greater than or equal to 1');
+    });
+  });
+
+  context("pageSize exceeds maximum", () => {
+    it("returns status 400", async () => {
+      const res = await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Cambridge&page=1&pageSize=101",
+      });
+
+      expect(res.statusCode).to.equal(400);
+      expect(res.result)
+        .to.have.property("message")
+        .that.includes('"pageSize" must be less than or equal to 100');
+    });
+  });
+
+  context("arguments passed to PBS", () => {
+    it("forwards searchTerm, page and pageSize from the request", async () => {
+      const stub = fake.resolves(pbsResponse);
+      sandbox.replace(proprietors, "searchProprietors", stub);
+
+      await server.inject({
+        ...validRequest,
+        url: "/api/proprietors?searchTerm=Test+Council&page=3&pageSize=25",
+      });
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.firstCall.args[0]).to.equal("Test Council");
+      expect(stub.firstCall.args[1]).to.equal(3);
+      expect(stub.firstCall.args[2]).to.equal(25);
     });
   });
 
@@ -161,15 +242,12 @@ describe("GET /api/proprietors", () => {
   });
 
   context("PBS throws an error", () => {
-    beforeEach(() => {
+    it("returns status 500", async () => {
       sandbox.replace(
         proprietors,
         "searchProprietors",
         fake.rejects(new Error("PBS unavailable")),
       );
-    });
-
-    it("returns status 500", async () => {
       const res = await server.inject(validRequest);
 
       expect(res.statusCode).to.equal(500);

--- a/src/routes/proprietors.test.ts
+++ b/src/routes/proprietors.test.ts
@@ -9,7 +9,7 @@ const proprietors = require("../queries/proprietors");
 
 const sandbox = createSandbox();
 
-describe.only("GET /api/proprietors", () => {
+describe("GET /api/proprietors", () => {
   let server: Server;
 
   const validRequest = {
@@ -79,6 +79,14 @@ describe.only("GET /api/proprietors", () => {
   });
 
   context("missing page (uses default)", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        proprietors,
+        "searchProprietors",
+        fake.resolves(pbsResponse),
+      );
+    });
+
     it("returns status 200", async () => {
       const res = await server.inject({
         ...validRequest,
@@ -91,6 +99,14 @@ describe.only("GET /api/proprietors", () => {
   });
 
   context("missing pageSize (uses default)", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        proprietors,
+        "searchProprietors",
+        fake.resolves(pbsResponse),
+      );
+    });
+
     it("returns status 200", async () => {
       const res = await server.inject({
         ...validRequest,

--- a/src/routes/proprietors.ts
+++ b/src/routes/proprietors.ts
@@ -3,9 +3,9 @@ import Joi from "joi";
 import { LoggedInRequest } from "./request_types";
 import { searchProprietors } from "../queries/proprietors";
 
-const DEFAULT_PAGE = 1;
-const DEFAULT_PAGE_SIZE = 10;
-const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE: number = 1;
+const DEFAULT_PAGE_SIZE: number = 10;
+const MAX_PAGE_SIZE: number = 100;
 
 type GetProprietorsRequest = LoggedInRequest & {
   query: {

--- a/src/routes/proprietors.ts
+++ b/src/routes/proprietors.ts
@@ -6,6 +6,7 @@ import { searchProprietors } from "../queries/proprietors";
 const DEFAULT_PAGE: number = 1;
 const DEFAULT_PAGE_SIZE: number = 10;
 const MAX_PAGE_SIZE: number = 100;
+const MAX_SEARCH_TERM_LENGTH: number = 200;
 
 type GetProprietorsRequest = LoggedInRequest & {
   query: {
@@ -33,7 +34,7 @@ async function getProprietors(
   request.raw.req.on("close", onClose);
 
   try {
-   // Forward client abort to PBS so in-flight requests are not left running
+    // Forward client abort to PBS so in-flight requests are not left running
     const result = await searchProprietors(
       searchTerm,
       page,
@@ -60,7 +61,10 @@ export const proprietorRoutes: ServerRoute[] = [
     options: {
       validate: {
         query: Joi.object({
-          searchTerm: Joi.string().required(),
+          searchTerm: Joi.string()
+            .min(1)
+            .max(MAX_SEARCH_TERM_LENGTH)
+            .required(),
           page: Joi.number().integer().min(1).optional().default(DEFAULT_PAGE),
           pageSize: Joi.number()
             .integer()

--- a/src/routes/proprietors.ts
+++ b/src/routes/proprietors.ts
@@ -1,0 +1,80 @@
+import { ResponseToolkit, ResponseObject, ServerRoute } from "@hapi/hapi";
+import Joi from "joi";
+import { LoggedInRequest } from "./request_types";
+import { searchProprietors } from "../queries/proprietors";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 100;
+
+type GetProprietorsRequest = LoggedInRequest & {
+  query: {
+    searchTerm: string;
+    page: number;
+    pageSize: number;
+  };
+};
+
+/**
+ * Handler for GET /api/proprietors. Proxies search request to the Property Boundaries Service and returns the response.
+ * Forwards client aborts to the PBS request so that in-flight requests are not left running unnecessarily.
+ * @param request - The incoming request, which includes query parameters for searchTerm, page, and pageSize.
+ * @param h - The Hapi response toolkit for constructing responses.
+ * @returns A response object containing the search results or an error message.
+ */
+async function getProprietors(
+  request: GetProprietorsRequest,
+  h: ResponseToolkit,
+): Promise<ResponseObject> {
+  const { searchTerm, page, pageSize } = request.query;
+
+  const abortController = new AbortController();
+  const onClose = () => abortController.abort();
+  request.raw.req.on("close", onClose);
+
+  try {
+   // Forward client abort to PBS so in-flight requests are not left running
+    const result = await searchProprietors(
+      searchTerm,
+      page,
+      pageSize,
+      abortController.signal,
+    );
+    return h.response(result).code(200);
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      return h.response().code(499);
+    }
+    console.error("Error in getProprietors:", error);
+    return h.response("Internal server error").code(500);
+  } finally {
+    request.raw.req.off("close", onClose);
+  }
+}
+
+export const proprietorRoutes: ServerRoute[] = [
+  {
+    method: "GET",
+    path: "/api/proprietors",
+    handler: getProprietors,
+    options: {
+      validate: {
+        query: Joi.object({
+          searchTerm: Joi.string().required(),
+          page: Joi.number().integer().min(1).optional().default(DEFAULT_PAGE),
+          pageSize: Joi.number()
+            .integer()
+            .min(1)
+            .max(MAX_PAGE_SIZE)
+            .optional()
+            .default(DEFAULT_PAGE_SIZE),
+        }),
+        failAction: (request, h, err) =>
+          h
+            .response({ message: (err as Error).message })
+            .code(400)
+            .takeover(),
+      },
+    },
+  },
+];

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { Request, Server } from "@hapi/hapi";
 import { userRoutes } from "./routes/user";
 import { mapRoutes } from "./routes/map";
 import { dataGroupRoutes } from "./routes/datagroup";
+import { proprietorRoutes } from "./routes/proprietors";
 import { setupWebsockets } from "./websockets/server";
 
 const AuthBearer = require("hapi-auth-bearer-token");
@@ -74,6 +75,7 @@ export const init = async function (): Promise<Server> {
   server.route(userRoutes);
   server.route(mapRoutes);
   server.route(dataGroupRoutes);
+  server.route(proprietorRoutes);
 
   // Log requests and response codes
   server.events.on("response", (request: any) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,7 +75,9 @@ export const init = async function (): Promise<Server> {
   server.route(userRoutes);
   server.route(mapRoutes);
   server.route(dataGroupRoutes);
-  server.route(proprietorRoutes);
+  if (process.env.MEILISEARCH_ENABLED === "true") {
+    server.route(proprietorRoutes);
+  }
 
   // Log requests and response codes
   server.events.on("response", (request: any) => {


### PR DESCRIPTION
#### What? Why?

Related to issue #82 

Part of the Backsearch epic.
This is the endpoint to get proprietors that the Land Explorer UI will call. It essentially proxies the request through to the Property boundary service.

#### Code-specific details (for Reviewer)
This is behind a feature flag. MEILISEARCH_ENABLED needs to be set in the env file for this feature to be switched on

#### Checklist

- [x] Updated or added any necessary docs in `docs/`
- [x] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

`https://staging.app.landexplorer.coop/api/proprietors?searchTerm=<search>&pageSize=<pageSize>&page=<page>`
where the user's JWT bearer token is set.
page and pageSize are optional

#### Deployment notes
The feature will initially be deployed switched off until the Meilisearch infrastructure has been deployed.
The feature can be turned on using the feature flag MEILISEARCH_ENABLED in the env file

