### PR TITLE
389 analytics opt out flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ GLITCHTIP_KEY=
 # For Mixpanel analytics, this token and pepper needs to be set
 # Changing the pepper will mean that old user IDs and map IDs can't be correlated
 MIXPANEL_TOKEN=<get this from the Mixpanel dashboard>
-ANALYTICS_PEPPER=<use a random string>
+ANALYTICS_PEPPER=<use a random string - this should match the value in the frontend .env file>

--- a/migrations/20260521154005-alter-user-add-analytics-consent.js
+++ b/migrations/20260521154005-alter-user-add-analytics-consent.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE user
+            ADD analytics_consent BOOLEAN DEFAULT NULL;`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE user
+             DROP COLUMN analytics_consent;`,
+    );
+  },
+};

--- a/src/queries/database.ts
+++ b/src/queries/database.ts
@@ -47,6 +47,7 @@ const UserModel = sequelize.define(
     enabled: DataTypes.INTEGER,
     is_super_user: { type: DataTypes.BOOLEAN, allowNull: false },
     ask_for_feedback: DataTypes.BOOLEAN,
+    analytics_consent: DataTypes.BOOLEAN,
 
     created_date: Sequelize.DATE,
     last_modified: Sequelize.DATE,
@@ -55,7 +56,7 @@ const UserModel = sequelize.define(
     tableName: "user",
     createdAt: "created_date",
     updatedAt: "last_modified",
-  }
+  },
 );
 
 const MapModel = sequelize.define(

--- a/src/queries/map.test.ts
+++ b/src/queries/map.test.ts
@@ -40,10 +40,10 @@ describe("trackUserMapEvent", () => {
     });
 
     it("calls trackUserEvent with consistent hashed mapId", async () => {
-      await trackUserMapEvent(testUserId, testMapId, Event.MAP.OPEN);
+      await trackUserMapEvent("test-session-id", testUserId, testMapId, Event.MAP.OPEN);
 
       expect(query.trackUserEvent.calledOnce).to.be.true;
-      const [userId, event, data] = (query.trackUserEvent as any).firstCall
+      const [, userId, event, data] = (query.trackUserEvent as any).firstCall
         .args;
 
       expect(userId).to.equal(testUserId);
@@ -55,13 +55,14 @@ describe("trackUserMapEvent", () => {
       const additionalData = { drawn_count: 5, access: "Readonly" };
 
       await trackUserMapEvent(
+        "test-session-id",
         testUserId,
         testMapId,
         Event.MAP.SHARED_OPEN,
         additionalData
       );
 
-      const [, , data] = (query.trackUserEvent as any).firstCall.args;
+      const [, , , data] = (query.trackUserEvent as any).firstCall.args;
 
       expect(data).to.deep.equal({
         drawn_count: 5,
@@ -71,8 +72,8 @@ describe("trackUserMapEvent", () => {
     });
 
     it("produces different hash for different mapId", async () => {
-      await trackUserMapEvent(testUserId, testMapId + 1, Event.MAP.OPEN);
-      const [, , data] = (query.trackUserEvent as any).firstCall.args;
+      await trackUserMapEvent("test-session-id", testUserId, testMapId + 1, Event.MAP.OPEN);
+      const [, , , data] = (query.trackUserEvent as any).firstCall.args;
       expect(data.map_id).to.not.equal("0936b464a63bf05d");
     });
   });
@@ -83,9 +84,9 @@ describe("trackUserMapEvent", () => {
     });
 
     it("uses MAP_NOT_FOUND as hashed mapId", async () => {
-      await trackUserMapEvent(testUserId, testMapId, Event.MAP.OPEN);
+      await trackUserMapEvent("test-session-id", testUserId, testMapId, Event.MAP.OPEN);
 
-      const [, , data] = (query.trackUserEvent as any).firstCall.args;
+      const [, , , data] = (query.trackUserEvent as any).firstCall.args;
       expect(data.map_id).to.equal("MAP_NOT_FOUND");
     });
   });
@@ -153,6 +154,7 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
     };
 
     await compareMapDataChangesAndSendAnalytics(
+      "test-session-id",
       testUserId,
       testMapId,
       oldData,
@@ -160,7 +162,7 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
     );
 
     expect(query.trackUserEvent.calledOnce).to.be.true;
-    const [, event, data] = (query.trackUserEvent as any).firstCall.args;
+    const [, , event, data] = (query.trackUserEvent as any).firstCall.args;
 
     expect(event).to.equal(Event.LAND_OWNERSHIP.ENABLE);
     expect(data.layer_id).to.equal("localAuthority");
@@ -177,6 +179,7 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
     };
 
     await compareMapDataChangesAndSendAnalytics(
+      "test-session-id",
       testUserId,
       testMapId,
       oldData,
@@ -184,7 +187,7 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
     );
 
     expect(query.trackUserEvent.calledOnce).to.be.true;
-    const [, event, data] = (query.trackUserEvent as any).firstCall.args;
+    const [, , event, data] = (query.trackUserEvent as any).firstCall.args;
 
     expect(event).to.equal(Event.LAND_OWNERSHIP.ENABLE);
     expect(data.layer_id).to.equal("localAuthority");
@@ -201,6 +204,7 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
     };
 
     compareMapDataChangesAndSendAnalytics(
+      "test-session-id",
       testUserId,
       testMapId,
       oldData,
@@ -231,6 +235,7 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
     };
 
     compareMapDataChangesAndSendAnalytics(
+      "test-session-id",
       testUserId,
       testMapId,
       oldData,

--- a/src/queries/map.ts
+++ b/src/queries/map.ts
@@ -52,13 +52,14 @@ const hashMapId = async (mapId: number) => {
  * a user's saved map.
  */
 export const trackUserMapEvent = async (
+  sessionId: string,
   userId: number,
   mapId: number,
   event: EventName,
-  data?: any
+  data?: any,
 ) => {
   const mapIdHash = await hashMapId(mapId);
-  trackUserEvent(userId, event, {
+  trackUserEvent(sessionId, userId, event, {
     ...data,
     map_id: mapIdHash,
   });
@@ -541,10 +542,11 @@ const copyDataGroupObjectsToNewMap = async (
 
 /** Returns ID of the created map */
 export const createMap = async (
+  sessionId: string,
   name: string,
   data: SaveMapData,
   userId: number,
-  isSnapshot: boolean
+  isSnapshot: boolean,
 ): Promise<number> => {
   // Saving drawings to DB separately so can remove from JSON
   const markers = data.markers.markers ?? [];
@@ -574,7 +576,7 @@ export const createMap = async (
     // In old maps, dataLayers used to be array of objects, each with an iddata_groups
     // field. In newer maps, myDataLayers is just an array of data group IDs.
     const dataGroupIds = myDataLayers.map((item: any) =>
-      typeof item === "number" ? item : item.iddata_groups
+      typeof item === "number" ? item : item.iddata_groups,
     );
     await copyDataGroupObjectsToNewMap(newMap.id, dataGroupIds);
 
@@ -588,12 +590,12 @@ export const createMap = async (
   await bulkCreateUpdateAndDeletePolygonsAndLines(
     newMap.id,
     polygonsAndLines,
-    false
+    false,
   );
 
   console.log(`Created map ${newMap.id} with name ${name}`);
 
-  trackUserMapEvent(userId, newMap.id, Event.MAP.FIRST_SAVE, {
+  trackUserMapEvent(sessionId, userId, newMap.id, Event.MAP.FIRST_SAVE, {
     // TODO: when we save properties, include this as properties_count
     drawings_count: markers.length + polygonsAndLines.length,
   });
@@ -635,10 +637,11 @@ export type SaveMapData = {
  * otherwise we add it to the DB. And we delete any items with UUIDs that are not in the new data.
  */
 export const updateMap = async (
+  sessionId: string,
   userId: number,
   mapId: number,
   name: string,
-  data: SaveMapData
+  data: SaveMapData,
 ) => {
   console.log(`User ${userId} updating map ${mapId}`);
 
@@ -650,7 +653,7 @@ export const updateMap = async (
     await bulkCreateUpdateAndDeletePolygonsAndLines(
       mapId,
       data.drawings.drawings,
-      true
+      true,
     );
   }
 
@@ -664,7 +667,13 @@ export const updateMap = async (
   const existingMap = await getMap(mapId);
   const existingMapData = JSON.parse(existingMap.data);
 
-  compareMapDataChangesAndSendAnalytics(userId, mapId, existingMapData, data);
+  compareMapDataChangesAndSendAnalytics(
+    sessionId,
+    userId,
+    mapId,
+    existingMapData,
+    data,
+  );
 
   // Save the new map data in the DB
   await Map.update(
@@ -676,7 +685,7 @@ export const updateMap = async (
       where: {
         id: mapId,
       },
-    }
+    },
   );
 };
 
@@ -687,28 +696,35 @@ export const updateMap = async (
  *   (this is the only one for now but we may choose to track more later)
  */
 export const compareMapDataChangesAndSendAnalytics = async (
+  sessionId: string,
   userId: number,
   mapId: number,
   oldData: SaveMapData,
-  newData: SaveMapData
+  newData: SaveMapData,
 ) => {
   const changes = atomizeChangeset(
     diff(oldData, newData, {
       keysToSkip: ["map", "drawings", "markers", "version"],
-    })
+    }),
   );
 
   const ownershipDisplayChange = changes.find(
     (change) =>
       (change.type === "ADD" || change.type === "UPDATE") &&
       change.value !== null &&
-      change.path.startsWith("$.mapLayers.ownershipDisplay")
+      change.path.startsWith("$.mapLayers.ownershipDisplay"),
   );
 
   if (ownershipDisplayChange) {
-    await trackUserMapEvent(userId, mapId, Event.LAND_OWNERSHIP.ENABLE, {
-      layer_id: ownershipDisplayChange.value,
-    });
+    await trackUserMapEvent(
+      sessionId,
+      userId,
+      mapId,
+      Event.LAND_OWNERSHIP.ENABLE,
+      {
+        layer_id: ownershipDisplayChange.value,
+      },
+    );
   }
 };
 
@@ -856,9 +872,10 @@ export const deleteMapAccessByEmails = async (
  *               emails that are granted access
  */
 export const grantMapAccessByEmails = async (
+  sessionId: string,
   mapId: number,
   users: { email: string; access: UserMapAccess }[],
-  domain: string = ""
+  domain: string = "",
 ) => {
   // email address comparison should be case insensitive
   const normalisedUsers = users.map(({ email, access }) => ({
@@ -873,7 +890,7 @@ export const grantMapAccessByEmails = async (
     ({ email, access }) => ({
       email: email.toLowerCase(),
       access,
-    })
+    }),
   );
 
   // Get emails that need to be removed from the DB (access has been completely revoked)
@@ -881,7 +898,7 @@ export const grantMapAccessByEmails = async (
     .map((oldUser) => oldUser.email)
     .filter(
       (oldEmail) =>
-        !normalisedUsers.map((newUser) => newUser.email).includes(oldEmail)
+        !normalisedUsers.map((newUser) => newUser.email).includes(oldEmail),
     );
 
   await deleteMapAccessByEmails(mapId, emailsToRemove);
@@ -892,7 +909,7 @@ export const grantMapAccessByEmails = async (
 
   for (const user of normalisedUsers) {
     const oldUser = oldUsersWithSharedMapAccess.find(
-      (oldUser) => oldUser.email === user.email
+      (oldUser) => oldUser.email === user.email,
     );
     if (oldUser) {
       if (oldUser.access !== user.access) {
@@ -966,10 +983,10 @@ export const grantMapAccessByEmails = async (
           ownerFirstName,
           ownerLastName,
           mapName,
-          domain
+          domain,
         );
       }
-      sharedWithAnalyticsData.push(await hashUserId(user.id));
+      sharedWithAnalyticsData.push(await hashUserId(user));
     } else {
       await PendingUserMap.create({
         map_id: mapId,
@@ -982,7 +999,7 @@ export const grantMapAccessByEmails = async (
           ownerFirstName,
           ownerLastName,
           mapName,
-          domain
+          domain,
         );
       }
       sharedWithAnalyticsData.push("PENDING_USER");
@@ -990,7 +1007,7 @@ export const grantMapAccessByEmails = async (
   }
 
   if (sharedWithAnalyticsData.length > 0) {
-    trackUserMapEvent(ownerUserId, mapId, Event.MAP.SHARE, {
+    trackUserMapEvent(sessionId, ownerUserId, mapId, Event.MAP.SHARE, {
       sharedWith: sharedWithAnalyticsData,
     });
   }

--- a/src/queries/map.ts
+++ b/src/queries/map.ts
@@ -59,7 +59,7 @@ export const trackUserMapEvent = async (
   data?: any,
 ) => {
   const mapIdHash = await hashMapId(mapId);
-  trackUserEvent(sessionId, userId, event, {
+  await trackUserEvent(sessionId, userId, event, {
     ...data,
     map_id: mapIdHash,
   });

--- a/src/queries/query.test.ts
+++ b/src/queries/query.test.ts
@@ -437,20 +437,17 @@ describe("trackUserEvent", () => {
     sandbox.restore();
   });
 
-  context("User exists", () => {
+  context("User exists with analytics consent", () => {
     beforeEach(() => {
-      sandbox.replace(
-        User,
-        "findOne",
-        fake.resolves({
-          id: testUserId,
-          created_date: testUserCreatedDate,
-        }),
-      );
+      sandbox.stub(User, "findOne").callsFake(async (options: any) => ({
+        id: options?.where?.id ?? testUserId,
+        created_date: testUserCreatedDate,
+        analytics_consent: true,
+      }));
     });
 
     it("calls trackRawEvent with consistent hashed userID", async () => {
-      await query.trackUserEvent(testUserId, "User_Register");
+      await query.trackUserEvent("test-session-id", testUserId, "User_Register");
 
       expect(trackRawEventSpy.calledOnce).to.be.true;
       const [event, data] = trackRawEventSpy.firstCall.args;
@@ -462,7 +459,7 @@ describe("trackUserEvent", () => {
     it("merges additional data", async () => {
       const additionalData = { shared_maps: true };
 
-      await query.trackUserEvent(testUserId, "User_Register", additionalData);
+      await query.trackUserEvent("test-session-id", testUserId, "User_Register", additionalData);
 
       const [, data] = trackRawEventSpy.firstCall.args;
       expect(data).to.deep.equal({
@@ -473,9 +470,38 @@ describe("trackUserEvent", () => {
     });
 
     it("produces different hash for different userId", async () => {
-      await query.trackUserEvent(testUserId + 1, "User_Register");
+      await query.trackUserEvent("test-session-id", testUserId + 1, "User_Register");
       const [, data] = trackRawEventSpy.firstCall.args;
       expect(data.distinct_id).to.not.equal("99a70b2e9c66404d");
+    });
+  });
+
+  context("User exists without analytics consent", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        User,
+        "findOne",
+        fake.resolves({
+          id: testUserId,
+          created_date: testUserCreatedDate,
+          analytics_consent: false,
+        }),
+      );
+    });
+
+    it("uses sessionId as distinct_id", async () => {
+      await query.trackUserEvent("test-session-id", testUserId, "User_Register");
+
+      expect(trackRawEventSpy.calledOnce).to.be.true;
+      const [, data] = trackRawEventSpy.firstCall.args;
+      expect(data.distinct_id).to.equal("test-session-id");
+    });
+
+    it("does not include user_groups", async () => {
+      await query.trackUserEvent("test-session-id", testUserId, "User_Register");
+
+      const [, data] = trackRawEventSpy.firstCall.args;
+      expect(data).to.not.have.property("user_groups");
     });
   });
 
@@ -485,7 +511,7 @@ describe("trackUserEvent", () => {
     });
 
     it("uses USER_NOT_FOUND as hashed userId", async () => {
-      await query.trackUserEvent(testUserId, "User_Register");
+      await query.trackUserEvent("test-session-id", testUserId, "User_Register");
       const [, data] = trackRawEventSpy.firstCall.args;
       expect(data.distinct_id).to.equal("USER_NOT_FOUND");
     });

--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -208,16 +208,8 @@ export const checkAndReturnUser = async (
  * Convert a userId to a hashed value, using their username as a salt and then adding the secret
  * pepper, to anonymize it for analytics.
  */
-export const hashUserId = async (userId: number) => {
-  if (userId === -1) return "USER_NOT_FOUND";
-
-  const user = await getUserById(userId);
-  if (!user) {
-    console.error(`User with ID ${userId} not found for hashing`);
-    return "USER_NOT_FOUND";
-  }
-
-  const saltAndPepperedInput = `${userId}${user.username}${process.env.ANALYTICS_PEPPER}`;
+export const hashUserId = async (user: typeof User) => {
+  const saltAndPepperedInput = `${user.id}${user.username}${process.env.ANALYTICS_PEPPER}`;
 
   return createHash("sha256")
     .update(saltAndPepperedInput)
@@ -228,35 +220,56 @@ export const hashUserId = async (userId: number) => {
 /**
  * The wrapper function that should be called for most analytic events in the app, where a user is
  * logged in.
+ * @param sessionId - This is a randomly generated string that identifies a user's session, used when we don't have consent to use the hashed user ID
+ * @param userId - The user's ID in our database
+ * @param event - The name of the event being tracked
+ * @param data - Any additional data to include with the event
  */
 export const trackUserEvent = async (
+  sessionId: string,
   userId: number,
   event: EventName,
-  data?: any
+  data?: any,
 ) => {
-  const userHash = await hashUserId(userId);
+  let analyticsUserId = sessionId; // default to sessionId if we don't have consent to use the hashed user ID
+  const user = await getUserById(userId);
+  if (!user) {
+    console.error(
+      `User with ID ${userId} not found for tracking event ${event}`,
+    );
+    analyticsUserId = "USER_NOT_FOUND";
+  }
+  let analyticsConsent = user?.analytics_consent ?? false; // default to false if null/undefined
 
-  // Include data on which user groups the user is a member of
-  const userGroups = await sequelize.query(
-    `SELECT ug.name
-     FROM user_group_memberships ugm
-     JOIN user_groups ug ON ugm.user_group_id = ug.iduser_groups
-     WHERE ugm.user_id = :userId`,
-    {
-      replacements: { userId },
-      type: QueryTypes.SELECT,
-    }
-  );
+  if (analyticsConsent) {
+    analyticsUserId = await hashUserId(user);
+    // Include data on which user groups the user is a member of
+    const userGroups = await sequelize.query(
+      `SELECT ug.name
+      FROM user_group_memberships ugm
+      JOIN user_groups ug ON ugm.user_group_id = ug.iduser_groups
+      WHERE ugm.user_id = :userId`,
+      {
+        replacements: { userId },
+        type: QueryTypes.SELECT,
+      },
+    );
 
-  const userGroupNames: string[] = userGroups
-    ? userGroups.map((ug: { name: string }) => ug.name)
-    : [];
+    const userGroupNames: string[] = userGroups
+      ? userGroups.map((ug: { name: string }) => ug.name)
+      : [];
 
-  trackRawEvent(event, {
-    ...data,
-    distinct_id: userHash,
-    user_groups: userGroupNames,
-  });
+    trackRawEvent(event, {
+      ...data,
+      distinct_id: analyticsUserId,
+      user_groups: userGroupNames,
+    });
+  } else {
+    trackRawEvent(event, {
+      ...data,
+      distinct_id: analyticsUserId,
+    });
+  }
 };
 
 /**

--- a/src/routes/map.ts
+++ b/src/routes/map.ts
@@ -72,6 +72,7 @@ async function saveMap(
   try {
     const { eid, name, data, isSnapshot } = request.payload;
     const userId = request.auth.credentials.user_id;
+    const { "x-session-id": sessionId } = request.headers;
 
     // eid provided means update map
     const isUpdate = eid !== null;
@@ -108,9 +109,15 @@ async function saveMap(
         return h.response("Map is locked").code(503);
       }
 
-      await updateMap(userId, eid, name, data);
+      await updateMap(sessionId, userId, eid, name, data);
     } else {
-      const newMapId = await createMap(name, data, userId, isSnapshot);
+      const newMapId = await createMap(
+        sessionId,
+        name,
+        data,
+        userId,
+        isSnapshot,
+      );
       await tryLockMap(newMapId, userId);
     }
 
@@ -469,6 +476,8 @@ async function shareMap(
   h: ResponseToolkit
 ): Promise<ResponseObject> {
   const originDomain = `https://${request.info.host}`;
+  const { "x-session-id": sessionId } = request.headers;
+
 
   const validation = new Validation();
   await validation.validateShareMap(request.payload);
@@ -495,7 +504,7 @@ async function shareMap(
     return h.response("Unauthorised!").code(403);
   }
 
-  await grantMapAccessByEmails(eid, users, originDomain);
+  await grantMapAccessByEmails(sessionId, eid, users, originDomain);
 
   return h.response().code(200);
 }
@@ -631,6 +640,7 @@ async function getMapData(
   try {
     const { eid } = request.params;
     const userId = request.auth.credentials.user_id;
+    const { "x-session-id": sessionId } = request.headers;
 
     const userMap = await UserMap.findOne({
       where: {
@@ -677,12 +687,12 @@ async function getMapData(
       // If the owner hasn't viewed the map before, this is due to the map just being saved for
       // the first time and immediately opened. So don't record a Map_Open event.
       if (userMap.viewed) {
-        trackUserMapEvent(userId, eid, Event.MAP.OPEN, {
+        trackUserMapEvent(sessionId, userId, eid, Event.MAP.OPEN, {
           drawn_count: drawnCount,
         });
       }
     } else {
-      trackUserMapEvent(userId, eid, Event.MAP.SHARED_OPEN, {
+      trackUserMapEvent(sessionId, userId, eid, Event.MAP.SHARED_OPEN, {
         drawn_count: drawnCount,
         access: UserMapAccess[userMap.access],
       });
@@ -828,10 +838,11 @@ async function searchOwnership(
 ): Promise<ResponseObject> {
   const { proprietorName } = request.query;
   const { user_id } = request.auth.credentials;
+  const { "x-session-id": sessionId } = request.headers;
 
   const titles = await searchOwner(proprietorName);
 
-  trackUserEvent(user_id, Event.LAND_OWNERSHIP.BACKSEARCH, {
+  trackUserEvent(sessionId, user_id, Event.LAND_OWNERSHIP.BACKSEARCH, {
     proprietor_name: proprietorName,
     properties_count: titles.length,
   });
@@ -855,6 +866,7 @@ async function downloadShapefile(
 ): Promise<ResponseObject> {
   const { mapId } = request.params;
   const { user_id } = request.auth.credentials;
+  const { "x-session-id": sessionId } = request.headers;
 
   const hasAccess = await UserMap.findOne({
     where: {
@@ -900,7 +912,7 @@ async function downloadShapefile(
 
   setTimeout(deleteFile, 5000);
 
-  trackUserMapEvent(user_id, mapId, Event.MAP.EXPORT_SHAPEFILE);
+  trackUserMapEvent(sessionId, user_id, mapId, Event.MAP.EXPORT_SHAPEFILE);
 
   return response;
 }
@@ -911,6 +923,7 @@ async function createMapGeoJSONLink(
 ): Promise<ResponseObject> {
   const { mapId } = request.payload;
   const { user_id } = request.auth.credentials;
+  const { "x-session-id": sessionId } = request.headers;
 
   const userMapView = await UserMap.findOne({
     where: {
@@ -922,7 +935,7 @@ async function createMapGeoJSONLink(
   if (userMapView?.access === UserMapAccess.Owner) {
     const publicMapAddress = await createPublicMapView(mapId);
 
-    trackUserMapEvent(user_id, mapId, Event.MAP.EXPORT_GEOJSON);
+    trackUserMapEvent(sessionId, user_id, mapId, Event.MAP.EXPORT_GEOJSON);
 
     return h.response(publicMapAddress);
   } else {
@@ -937,6 +950,7 @@ async function getPublicMap(
   h: ResponseToolkit
 ): Promise<ResponseObject> {
   const { mapId } = request.params;
+  const { "x-session-id": sessionId } = request.headers;
 
   const publicMapView = await UserMap.findOne({
     where: {
@@ -947,7 +961,7 @@ async function getPublicMap(
 
   if (publicMapView) {
     const geoJsonData = await getGeoJsonFeaturesForMap(mapId);
-    trackUserMapEvent(-1, mapId, Event.MAP.GEOJSON_OPEN);
+    trackUserMapEvent(sessionId, -1, mapId, Event.MAP.GEOJSON_OPEN);
     return h.response(geoJsonData);
   } else {
     return h.response("No public map at this address.").code(404);

--- a/src/routes/request_types.ts
+++ b/src/routes/request_types.ts
@@ -8,4 +8,7 @@ export type LoggedInRequest = Request & {
       user_id: number;
     };
   };
+  headers: Request["headers"] & {
+    ["x-session-id"]: string;
+  };
 };

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -318,3 +318,123 @@ describe("POST /api/user/password-reset", () => {
 
     });
 });
+
+describe("GET /api/user/details", () => {
+    const testUserId = 123;
+
+    beforeEach(async () => {
+        server = await init();
+    });
+
+    afterEach(async () => {
+        await server.stop();
+        sandbox.restore();
+    });
+
+    context("User exists", () => {
+        it("returns analyticsConsent: true when set", async () => {
+            sandbox.replace(Model.User, "findOne", fake.resolves({
+                id: testUserId,
+                username: "douglas.quaid@yahoomail.com",
+                first_name: "Douglas",
+                last_name: "Quaid",
+                analytics_consent: true,
+            }));
+
+            const res = await server.inject({
+                method: "GET",
+                url: "/api/user/details",
+                auth: { strategy: "simple", credentials: { user_id: testUserId } },
+            });
+
+            expect(res.statusCode).to.equal(200);
+            expect((res.result as any).analyticsConsent).to.equal(true);
+        });
+
+        it("returns analyticsConsent: false when not set", async () => {
+            sandbox.replace(Model.User, "findOne", fake.resolves({
+                id: testUserId,
+                username: "douglas.quaid@yahoomail.com",
+                first_name: "Douglas",
+                last_name: "Quaid",
+                analytics_consent: false,
+            }));
+
+            const res = await server.inject({
+                method: "GET",
+                url: "/api/user/details",
+                auth: { strategy: "simple", credentials: { user_id: testUserId } },
+            });
+
+            expect(res.statusCode).to.equal(200);
+            expect((res.result as any).analyticsConsent).to.equal(false);
+        });
+    });
+});
+
+describe("POST /api/user/analytics-consent", () => {
+    const testUserId = 123;
+    let fakeUserUpdate: SinonSpy;
+
+    beforeEach(async () => {
+        server = await init();
+        fakeUserUpdate = sandbox.replace(Model.User, "update", fake.resolves([1]));
+    });
+
+    afterEach(async () => {
+        await server.stop();
+        sandbox.restore();
+    });
+
+    it("returns status 200 and persists consent when set to true", async () => {
+        const res = await server.inject({
+            method: "POST",
+            url: "/api/user/analytics-consent",
+            auth: { strategy: "simple", credentials: { user_id: testUserId } },
+            payload: { analyticsConsent: true },
+        });
+
+        expect(res.statusCode).to.equal(200);
+        assert.calledOnceWithMatch(fakeUserUpdate,
+            { analytics_consent: true },
+            { where: { id: testUserId } }
+        );
+    });
+
+    it("returns status 200 and persists consent when set to false", async () => {
+        const res = await server.inject({
+            method: "POST",
+            url: "/api/user/analytics-consent",
+            auth: { strategy: "simple", credentials: { user_id: testUserId } },
+            payload: { analyticsConsent: false },
+        });
+
+        expect(res.statusCode).to.equal(200);
+        assert.calledOnceWithMatch(fakeUserUpdate,
+            { analytics_consent: false },
+            { where: { id: testUserId } }
+        );
+    });
+
+    it("returns status 400 when payload is missing analyticsConsent", async () => {
+        const res = await server.inject({
+            method: "POST",
+            url: "/api/user/analytics-consent",
+            auth: { strategy: "simple", credentials: { user_id: testUserId } },
+            payload: {},
+        });
+
+        expect(res.statusCode).to.equal(400);
+    });
+
+    it("returns status 400 when analyticsConsent is not a boolean", async () => {
+        const res = await server.inject({
+            method: "POST",
+            url: "/api/user/analytics-consent",
+            auth: { strategy: "simple", credentials: { user_id: testUserId } },
+            payload: { analyticsConsent: "yes" },
+        });
+
+        expect(res.statusCode).to.equal(400);
+    });
+});

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -21,6 +21,8 @@ import { User, PasswordResetToken } from "../queries/database";
 import { hashPassword, generateRandomToken } from "../queries/helper";
 import { LoggedInRequest } from "./request_types";
 import { Event } from "../instrument";
+import Joi from "joi";
+import { UpdateAnalyticsConsentRequest } from "./user.types";
 
 const RESET_PASSWORD_EXPIRY_HOURS = 24;
 
@@ -56,7 +58,7 @@ async function registerUser(
   const mapsCount = await migrateGuestUserMap(user);
 
   // send analytic
-  trackUserEvent(user.id, Event.USER.REGISTER, {
+  trackUserEvent(crypto.randomUUID(), user.id, Event.USER.REGISTER, {
     sharedMaps: mapsCount > 0,
   });
 
@@ -163,6 +165,7 @@ async function getAuthUserDetails(
     phone: user.phone ?? "",
     council_id: user.council_id ?? 0,
     is_super_user: user.is_super_user ?? 0,
+    analyticsConsent: user.analytics_consent,
   });
 }
 
@@ -353,6 +356,8 @@ async function userFeedback(
     request.auth.credentials.user_id
   );
 
+  const { "x-session-id": sessionId } = request.headers;
+
   await User.update(
     { ask_for_feedback: false },
     {
@@ -362,12 +367,17 @@ async function userFeedback(
     }
   );
 
-  trackUserEvent(request.auth.credentials.user_id, Event.USER.FEEDBACK, {
-    question_use_case,
-    question_impact,
-    question_who_benefits,
-    question_improvements,
-  });
+  trackUserEvent(
+    sessionId,
+    request.auth.credentials.user_id,
+    Event.USER.FEEDBACK,
+    {
+      question_use_case,
+      question_impact,
+      question_who_benefits,
+      question_improvements,
+    },
+  );
 
   return h.response(userFeedback).code(200);
 }
@@ -435,6 +445,18 @@ async function getUserAskForFeedback(
   return h.response({ askForFeedback }).code(200);
 }
 
+async function updateAnalyticsConsent(
+  request: UpdateAnalyticsConsentRequest,
+  h: ResponseToolkit,
+): Promise<ResponseObject> {
+  await User.update(
+    { analytics_consent: request.payload.analyticsConsent },
+    { where: { id: request.auth.credentials.user_id } },
+  );
+
+  return h.response().code(200);
+}
+
 export const userRoutes: ServerRoute[] = [
   /** Public APIs */
   // Register a new account
@@ -482,4 +504,22 @@ export const userRoutes: ServerRoute[] = [
   { method: "POST", path: "/api/user/password", handler: changePassword },
   // Allow logged in user to submit feedback
   { method: "POST", path: "/api/user/feedback", handler: userFeedback },
+  // Update analytics consent
+  {
+    method: "POST",
+    path: "/api/user/analytics-consent",
+    handler: updateAnalyticsConsent,
+    options: {
+      validate: {
+        payload: Joi.object({
+          analyticsConsent: Joi.boolean().required(),
+        }),
+        failAction: (request, h, err) =>
+          h
+            .response({ message: (err as Error).message })
+            .code(400)
+            .takeover(),
+      },
+    },
+  },
 ];

--- a/src/routes/user.types.ts
+++ b/src/routes/user.types.ts
@@ -1,0 +1,9 @@
+import { LoggedInRequest } from "./request_types";
+
+type UpdateAnalyticsConsentPayload = {
+  analyticsConsent: boolean;
+};
+
+export type UpdateAnalyticsConsentRequest = LoggedInRequest & {
+  payload: UpdateAnalyticsConsentPayload;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { dataGroupRoutes } from "./routes/datagroup";
 import { proprietorRoutes } from "./routes/proprietors";
 import { setupWebsockets } from "./websockets/server";
 
+
 const AuthBearer = require("hapi-auth-bearer-token");
 const Inert = require("@hapi/inert");
 const jwt = require("jsonwebtoken");
@@ -33,7 +34,7 @@ export const init = async function (): Promise<Server> {
       cors: process.env.NODE_ENV === "development" && {
         origin: ["http://localhost:8080"],
         // Allow WebSocket connections
-        additionalHeaders: ["authorization", "content-type"],
+        additionalHeaders: ["authorization", "content-type", "x-session-id"],
       },
     },
   });


### PR DESCRIPTION
#### What? Why?

Fixes #389 

This adds the backend for the analytics opt in/out flow. The flow is as follows:
- When a user logs in, if they haven't previously allowed/disallowed they will be shown a consent banner. 
- Their response is stored in the DB and they won't be shown the banner again. 
- There is a new setting under My account > privacy settings for them to change their analytics consent at a later point.
  - If the user allows analytics - we turn on both frontend and backend analytics. We use a pseudonymous hashing method for the userId in analytics so we can track patterns across sessions, but who the user is stays well hidden.
  - If the user says no to analytics - we turn off frontend analytics completely and use a random Id for the backend analytics so that it is fully anonymous. It stays the same for that session but changes between sessions, so we lose the cross-session tracking in that case.

#### What should we test? (for QA)
- On login, each user should see a consent banner (this will show for all users who haven't yet answered the consent question)
- Once the consent banner has been answered, subsequent logins or refreshes shouldn't show the consent banner.
- Check that the backend analytics works as expected (there are no FE analytics implemented yet)
- Check that switching the analytics consent on/off does follow the rules set out above.

#### Deployment notes
None