### PR TITLE
92 containerise

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md
+
+**/lib
+**/downloads
+**/logs
+**/analysis
+
+**/.env.*
+
+**/compose*
+**/secrets
+
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib/
 node_modules/
 .env
+docker.env
 data/shapefiles/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,31 @@ RUN npm run build
 FROM node:${NODE_VERSION}-alpine
 WORKDIR /app
 
-# Default to production. The dev compose overrides this to `development` so the
-# back-end's CORS allows the local front-end origin (see src/server.ts).
+# Default to production. The dev compose overrides this to `development`. In
+# deployed environments set CORS_ORIGINS to the front-end origin so the API
+# accepts its cross-origin requests (see src/server.ts).
 ENV NODE_ENV=production
 
-# Compiled app + node_modules + the Sequelize config, then strip dev deps
-# (keeping compiled native modules like bcrypt intact).
+# Compiled app + node_modules + the Sequelize config.
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/lib ./lib
 COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
 COPY --from=build /app/config ./config
-RUN npm prune --omit=dev
+
+# DB migrations run at deploy time (e.g. Coolify's pre-deploy command:
+# `npx sequelize-cli db:migrate`). Bring in the migration sources and the
+# Sequelize config so the CLI can run inside this image. `models/` isn't needed
+# by db:migrate and doesn't exist in this repo.
+COPY --from=build /app/migrations ./migrations
+COPY --from=build /app/seeders ./seeders
+COPY --from=build /app/.sequelizerc ./.sequelizerc
+
+# Strip dev deps to slim the image (keeping compiled native modules like bcrypt
+# intact), then add back just the Sequelize CLI - a dev dep, but needed to run
+# migrations at deploy time. Pinned to the major version in package.json.
+RUN npm prune --omit=dev \
+    && npm install --no-save sequelize-cli@6
 
 USER node
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# Multi-stage build for the Land Explorer back-end (Hapi, TypeScript compiled
+# to lib/ with tsc). Modelled on mykomap-monolith/apps/back-end/Dockerfile.
+# See docs/coolify.md for how to build and run this.
+#
+# Note: unlike the Mykomap back-end (which is bundled by Vite), this app is
+# compiled with plain tsc and is NOT bundled, so it needs its production
+# node_modules present at runtime.
+
+# Node version must be supplied (e.g. 24). No sane default - fail loudly if unset.
+ARG NODE_VERSION=nonesuch
+
+# ---- build stage ----
+FROM node:${NODE_VERSION}-alpine AS build
+WORKDIR /app
+
+# git: lets the build read tag/commit info for version metadata.
+# python3/make/g++: needed to compile the native `bcrypt` dependency on musl.
+RUN apk add --no-cache git python3 make g++
+
+# Install deps first (cache-friendly), then bring in source and compile.
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+COPY . .
+RUN npm run build
+# NB: dev dependencies are kept in this stage so the compose `migrate` service
+# (which targets this stage) has sequelize-cli available. The runtime stage
+# prunes them.
+
+# ---- runtime stage ----
+FROM node:${NODE_VERSION}-alpine
+WORKDIR /app
+
+# Default to production. The dev compose overrides this to `development` so the
+# back-end's CORS allows the local front-end origin (see src/server.ts).
+ENV NODE_ENV=production
+
+# Compiled app + node_modules + the Sequelize config, then strip dev deps
+# (keeping compiled native modules like bcrypt intact).
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/lib ./lib
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/config ./config
+RUN npm prune --omit=dev
+
+USER node
+EXPOSE 4000
+
+# Docker is the process supervisor; we run node directly rather than via pm2.
+CMD ["node", "lib/main.js"]

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -69,6 +69,17 @@ services:
       - "27700:7700"
     networks:
       - lx
+    # Meilisearch has a build-in health check at GET /health
+    # Use it to wait for lx-pbs to know when it is ready
+    #   (service_healthy not service_started)
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://127.0.0.1:7700/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+    networks:
+      - lx
 
   # One-shot: apply the LX back-end DB migrations, then exit. Runs the runtime
   # image (which now ships the migration sources + sequelize-cli), so this
@@ -181,7 +192,7 @@ services:
       lx-mysql:
         condition: service_healthy
       lx-meilisearch:
-        condition: service_started
+        condition: service_healthy
       lx-pbs-migrate:
         condition: service_completed_successfully
     networks:

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -213,6 +213,11 @@ services:
         VITE_OS_KEY: ${VITE_OS_KEY:?missing - download docker.env from Bitwarden and run with --env-file docker.env}
         VITE_GEOCODER_TOKEN: ${VITE_GEOCODER_TOKEN:?missing - download docker.env from Bitwarden and run with --env-file docker.env}
         VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:?missing - download docker.env from Bitwarden and run with --env-file docker.env}
+        # Optional build args - these won't be wired up if they are unset
+        VITE_USER_GUIDE_URL: ${VITE_USER_GUIDE_URL:-}
+        VITE_MIXPANEL_TOKEN: ${VITE_MIXPANEL_TOKEN:-}
+        VITE_MIXPANEL_PEPPER: ${VITE_MIXPANEL_PEPPER:-}
+
     container_name: lx-fe
     ports:
       - "28080:80"

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -12,10 +12,17 @@
 #
 # Usage (from this repo's root):
 #   docker compose -f compose.all.yml up --build
-# then open http://localhost:8080
+# then open the front-end at http://localhost:28080
+#
+# Host ports are deliberately uncommon (28080/24000/24001/23306/27700) so they
+# don't clash with anything else you have running (a local MySQL on 3306, a dev
+# server on 8080, etc.). The container-internal ports are unchanged. If you
+# change a port here, update the matching value:
+#   - front-end host port  -> back-end CORS_ORIGINS (browser origin)
+#   - back-end host port    -> front-end VITE_ROOT_URL (where the SPA calls the API)
 #
 # The values below are DEV-ONLY throwaway credentials. Real secrets are handled
-# via Docker secrets in the per-repo production compose files (see docs/coolify.md).
+# via Coolify in deployed environments (see technology-and-infrastructure).
 #
 # Map tiles need real Ordnance Survey / Mapbox keys to render; with the
 # placeholder keys below the app and login work but the map won't draw. Set
@@ -25,15 +32,16 @@
 name: land-explorer-dev
 
 services:
-  mysql:
+  lx-mysql:
     image: mysql:8
+    container_name: lx-mysql
     environment:
       MYSQL_ROOT_PASSWORD: devroot
     volumes:
       - mysql_data:/var/lib/mysql
       - ./docker/mysql-init:/docker-entrypoint-initdb.d:ro
     ports:
-      - "3306:3306"
+      - "23306:3306"
     # Ping over TCP (not the unix socket) so "healthy" means the network port is
     # actually accepting connections - during first-init MySQL briefly serves a
     # temporary server on the socket only, and a socket ping would pass too early.
@@ -46,136 +54,144 @@ services:
     networks:
       - lx
 
-  meilisearch:
+  lx-meilisearch:
     image: getmeili/meilisearch:v1.41.0
+    container_name: lx-meilisearch
     environment:
       MEILI_MASTER_KEY: devmasterkey
       MEILI_ENV: development
     volumes:
       - meilisearch_data:/meili_data
     ports:
-      - "7700:7700"
+      - "27700:7700"
     networks:
       - lx
 
   # One-shot: apply the LX back-end DB migrations, then exit. Runs the runtime
   # image (which now ships the migration sources + sequelize-cli), so this
   # exercises the same migrate path Coolify uses via its pre-deploy command.
-  back-end-migrate:
+  lx-be-migrate:
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
+    container_name: lx-be-migrate
     command: ["npx", "sequelize-cli", "db:migrate"]
     environment:
       NODE_ENV: development
-      DATABASE_HOST: mysql
+      DATABASE_HOST: lx-mysql
       DATABASE_PORT: "3306"
       DATABASE_USER: root
       DATABASE_PASSWORD: devroot
       DATABASE_NAME: land_explorer
     depends_on:
-      mysql:
+      lx-mysql:
         condition: service_healthy
     restart: "no"
     networks:
       - lx
 
-  back-end:
+  lx-be:
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
-    # NODE_ENV=development so the back-end's CORS allows the http://localhost:8080
-    # front-end origin (see src/server.ts).
+    container_name: lx-be
     environment:
       NODE_ENV: development
       PORT: "4000"
-      DATABASE_HOST: mysql
+      # The front-end runs on host port 28080, so that's its browser origin.
+      # This is what lets the SPA call the API cross-origin (see src/cors.ts).
+      CORS_ORIGINS: http://localhost:28080
+      DATABASE_HOST: lx-mysql
       DATABASE_PORT: "3306"
       DATABASE_USER: root
       DATABASE_PASSWORD: devroot
       DATABASE_NAME: land_explorer
       TOKEN_KEY: dev-token-key-not-for-production
       TOKEN_EXPIRY_DAYS: "365"
-      BOUNDARY_SERVICE_URL: http://pbs:4000
+      BOUNDARY_SERVICE_URL: http://lx-pbs:4000
       BOUNDARY_SERVICE_SECRET: devsecret
       MEILISEARCH_ENABLED: "true"
     ports:
-      - "4000:4000"
+      - "24000:4000"
     depends_on:
-      mysql:
+      lx-mysql:
         condition: service_healthy
-      back-end-migrate:
+      lx-be-migrate:
         condition: service_completed_successfully
     networks:
       - lx
 
-  # One-shot: apply the PBS DB migrations, then exit. Like back-end-migrate, this
+  # One-shot: apply the PBS DB migrations, then exit. Like lx-be-migrate, this
   # runs the runtime image so it mirrors the Coolify pre-deploy migrate path.
-  pbs-migrate:
+  lx-pbs-migrate:
     build:
       context: ../property-boundaries-service
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
+    container_name: lx-pbs-migrate
     command: ["npx", "sequelize-cli", "db:migrate"]
     environment:
       NODE_ENV: development
-      DB_HOST: mysql
+      DB_HOST: lx-mysql
       DB_USER: root
       DB_PASSWORD: devroot
       DB_NAME: property_boundaries
     depends_on:
-      mysql:
+      lx-mysql:
         condition: service_healthy
     restart: "no"
     networks:
       - lx
 
-  pbs:
+  lx-pbs:
     build:
       context: ../property-boundaries-service
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
+    container_name: lx-pbs
     environment:
       NODE_ENV: development
       PORT: "4000"
-      DB_HOST: mysql
+      DB_HOST: lx-mysql
       DB_USER: root
       DB_PASSWORD: devroot
       DB_NAME: property_boundaries
       SECRET: devsecret
       MEILISEARCH_ENABLED: "true"
-      MEILI_HOST: http://meilisearch:7700
+      MEILI_HOST: http://lx-meilisearch:7700
       MEILI_MASTER_KEY: devmasterkey
     ports:
-      - "4001:4000"
+      - "24001:4000"
     depends_on:
-      mysql:
+      lx-mysql:
         condition: service_healthy
-      meilisearch:
+      lx-meilisearch:
         condition: service_started
-      pbs-migrate:
+      lx-pbs-migrate:
         condition: service_completed_successfully
     networks:
       - lx
 
-  front-end:
+  lx-fe:
     build:
       context: ../land-explorer-front-end
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
         CADDY_HOSTNAME: localhost
         # The SPA calls the back-end cross-origin at this URL (baked in at build).
-        VITE_ROOT_URL: http://localhost:4000
+        # Must match the back-end's host port (24000).
+        VITE_ROOT_URL: http://localhost:24000
         # Placeholders - replace with real keys to render the map.
         VITE_OS_KEY: ${VITE_OS_KEY:-placeholder}
         VITE_GEOCODER_TOKEN: ${VITE_GEOCODER_TOKEN:-placeholder}
         VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-placeholder}
+    container_name: lx-fe
     ports:
-      - "8080:80"
+      - "28080:80"
     depends_on:
-      - back-end
+      - lx-be
     networks:
       - lx
 

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -82,13 +82,15 @@ services:
   # One-shot: apply the LX back-end DB migrations, then exit. Runs the runtime
   # image (which now ships the migration sources + sequelize-cli), so this
   # exercises the same migrate path Coolify uses via its pre-deploy command.
+  # Also ensure the database exists with a sequelize db:create if something
+  #  went wrong in the mysql container creation.
   lx-be-migrate:
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
     container_name: lx-be-migrate
-    command: ["npx", "sequelize-cli", "db:migrate"]
+    command: ["sh", "-c", "npx sequelize-cli db:create || true; npx sequelize-cli db:migrate"]
     environment:
       NODE_ENV: development
       DATABASE_HOST: lx-mysql
@@ -148,7 +150,7 @@ services:
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
     container_name: lx-pbs-migrate
-    command: ["npx", "sequelize-cli", "db:migrate"]
+    command: ["sh", "-c", "npx sequelize-cli db:create || true; npx sequelize-cli db:migrate"]
     environment:
       NODE_ENV: development
       DB_HOST: lx-mysql

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -198,6 +198,32 @@ services:
     networks:
       - lx
 
+  # Optional one-shot: populate the proprietor data + Meilisearch index
+  #  When starting we get no prop boundaries and no meilisearch index
+  #  This triggers the ownerships + updateProprietors tasks
+  # TODO: It stops before downloadInspire which is failing - see
+  #  https://github.com/DigitalCommons/property-boundaries-service/issues/45
+  # It does not run on a normal up - it takes a LONG time to run and need
+  #  real GOV_API_ keys - if you need it for testing run it explicity once
+  #  everything is up and watch lx-pbs logs for progress:
+  #   docker compose --env-file docker.env -f compose.all.yml --profile seed up lx-pbs-seed
+  lx-pbs-seed:
+    image: curlimages/curl:8.11.1
+    container_name: lx-pbs-seed
+    profiles: ["seed"]
+    command:
+      - "--retry"
+      - "30"
+      - "--retry-connrefused"
+      - "--retry-delay"
+      - "5"
+      - "http://lx-pbs:4000/run-pipeline?secret=devsecret&startAtTask=ownerships&stopBeforeTask=downloadInspire"
+    depends_on:
+      - lx-pbs
+    restart: "no"
+    networks:
+      - lx
+
   lx-fe:
     build:
       context: ../land-explorer-front-end

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -111,6 +111,27 @@ services:
     networks:
       - lx
 
+  # One-shot: apply the PBS DB migrations, then exit. Like back-end-migrate, this
+  # runs the runtime image so it mirrors the Coolify pre-deploy migrate path.
+  pbs-migrate:
+    build:
+      context: ../property-boundaries-service
+      args:
+        NODE_VERSION: ${NODE_VERSION:-24}
+    command: ["npx", "sequelize-cli", "db:migrate"]
+    environment:
+      NODE_ENV: development
+      DB_HOST: mysql
+      DB_USER: root
+      DB_PASSWORD: devroot
+      DB_NAME: property_boundaries
+    depends_on:
+      mysql:
+        condition: service_healthy
+    restart: "no"
+    networks:
+      - lx
+
   pbs:
     build:
       context: ../property-boundaries-service
@@ -134,6 +155,8 @@ services:
         condition: service_healthy
       meilisearch:
         condition: service_started
+      pbs-migrate:
+        condition: service_completed_successfully
     networks:
       - lx
 

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -67,8 +67,6 @@ services:
       - meilisearch_data:/meili_data
     ports:
       - "27700:7700"
-    networks:
-      - lx
     # Meilisearch has a build-in health check at GET /health
     # Use it to wait for lx-pbs to know when it is ready
     #   (service_healthy not service_started)

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -1,0 +1,164 @@
+# Local development stack for the WHOLE Land Explorer system:
+#   front-end + back-end + property-boundaries-service + MySQL + Meilisearch.
+#
+# This file is a *local development aid* - one command to bring the whole stack
+# up. It is NOT the production deployment artefact (each repo has its own
+# single-app docker-compose.yml for that). It refers to the sibling repos by
+# relative path, so it assumes the standard checkout layout:
+#
+#   <somewhere>/land-explorer-back-end       <- this repo (run compose from here)
+#   <somewhere>/land-explorer-front-end
+#   <somewhere>/property-boundaries-service
+#
+# Usage (from this repo's root):
+#   docker compose -f compose.all.yml up --build
+# then open http://localhost:8080
+#
+# The values below are DEV-ONLY throwaway credentials. Real secrets are handled
+# via Docker secrets in the per-repo production compose files (see docs/coolify.md).
+#
+# Map tiles need real Ordnance Survey / Mapbox keys to render; with the
+# placeholder keys below the app and login work but the map won't draw. Set
+# VITE_OS_KEY / VITE_MAPBOX_TOKEN / VITE_GEOCODER_TOKEN below (or via your shell)
+# to see the map.
+
+name: land-explorer-dev
+
+services:
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: devroot
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./docker/mysql-init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "3306:3306"
+    # Ping over TCP (not the unix socket) so "healthy" means the network port is
+    # actually accepting connections - during first-init MySQL briefly serves a
+    # temporary server on the socket only, and a socket ping would pass too early.
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--protocol=TCP", "-uroot", "-pdevroot", "--silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 40s
+    networks:
+      - lx
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.41.0
+    environment:
+      MEILI_MASTER_KEY: devmasterkey
+      MEILI_ENV: development
+    volumes:
+      - meilisearch_data:/meili_data
+    ports:
+      - "7700:7700"
+    networks:
+      - lx
+
+  # One-shot: apply the LX back-end DB migrations, then exit. Uses the build
+  # stage (which still has dev deps incl. sequelize-cli and the full source).
+  back-end-migrate:
+    build:
+      context: .
+      target: build
+      args:
+        NODE_VERSION: ${NODE_VERSION:-24}
+    command: ["npx", "sequelize-cli", "db:migrate"]
+    environment:
+      NODE_ENV: development
+      DATABASE_HOST: mysql
+      DATABASE_PORT: "3306"
+      DATABASE_USER: root
+      DATABASE_PASSWORD: devroot
+      DATABASE_NAME: land_explorer
+    depends_on:
+      mysql:
+        condition: service_healthy
+    restart: "no"
+    networks:
+      - lx
+
+  back-end:
+    build:
+      context: .
+      args:
+        NODE_VERSION: ${NODE_VERSION:-24}
+    # NODE_ENV=development so the back-end's CORS allows the http://localhost:8080
+    # front-end origin (see src/server.ts).
+    environment:
+      NODE_ENV: development
+      PORT: "4000"
+      DATABASE_HOST: mysql
+      DATABASE_PORT: "3306"
+      DATABASE_USER: root
+      DATABASE_PASSWORD: devroot
+      DATABASE_NAME: land_explorer
+      TOKEN_KEY: dev-token-key-not-for-production
+      TOKEN_EXPIRY_DAYS: "365"
+      BOUNDARY_SERVICE_URL: http://pbs:4000
+      BOUNDARY_SERVICE_SECRET: devsecret
+      MEILISEARCH_ENABLED: "true"
+    ports:
+      - "4000:4000"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      back-end-migrate:
+        condition: service_completed_successfully
+    networks:
+      - lx
+
+  pbs:
+    build:
+      context: ../property-boundaries-service
+      args:
+        NODE_VERSION: ${NODE_VERSION:-24}
+    environment:
+      NODE_ENV: development
+      PORT: "4000"
+      DB_HOST: mysql
+      DB_USER: root
+      DB_PASSWORD: devroot
+      DB_NAME: property_boundaries
+      SECRET: devsecret
+      MEILISEARCH_ENABLED: "true"
+      MEILI_HOST: http://meilisearch:7700
+      MEILI_MASTER_KEY: devmasterkey
+    ports:
+      - "4001:4000"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      meilisearch:
+        condition: service_started
+    networks:
+      - lx
+
+  front-end:
+    build:
+      context: ../land-explorer-front-end
+      args:
+        NODE_VERSION: ${NODE_VERSION:-24}
+        CADDY_HOSTNAME: localhost
+        # The SPA calls the back-end cross-origin at this URL (baked in at build).
+        VITE_ROOT_URL: http://localhost:4000
+        # Placeholders - replace with real keys to render the map.
+        VITE_OS_KEY: ${VITE_OS_KEY:-placeholder}
+        VITE_GEOCODER_TOKEN: ${VITE_GEOCODER_TOKEN:-placeholder}
+        VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-placeholder}
+    ports:
+      - "8080:80"
+    depends_on:
+      - back-end
+    networks:
+      - lx
+
+volumes:
+  mysql_data:
+  meilisearch_data:
+
+networks:
+  lx:

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -58,12 +58,12 @@ services:
     networks:
       - lx
 
-  # One-shot: apply the LX back-end DB migrations, then exit. Uses the build
-  # stage (which still has dev deps incl. sequelize-cli and the full source).
+  # One-shot: apply the LX back-end DB migrations, then exit. Runs the runtime
+  # image (which now ships the migration sources + sequelize-cli), so this
+  # exercises the same migrate path Coolify uses via its pre-deploy command.
   back-end-migrate:
     build:
       context: .
-      target: build
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
     command: ["npx", "sequelize-cli", "db:migrate"]

--- a/compose.all.yml
+++ b/compose.all.yml
@@ -10,9 +10,16 @@
 #   <somewhere>/land-explorer-front-end
 #   <somewhere>/property-boundaries-service
 #
-# Usage (from this repo's root):
-#   docker compose -f compose.all.yml up --build
+# Usage (from this repo's root) - REQUIRES the secrets file `docker.env`, which
+# you download from Bitwarden (it is gitignored; see docker.env.example for the
+# list of keys). Compose fails fast if it's missing:
+#   docker compose --env-file docker.env -f compose.all.yml up --build
 # then open the front-end at http://localhost:28080
+#
+# Why --env-file AND env_file: the back-end / PBS services load docker.env at
+# runtime via `env_file:` (so a missing file is a hard error), while the
+# front-end's VITE_* map keys are *build args* that Compose can only resolve
+# through --env-file (a service env_file does not feed build-time interpolation).
 #
 # Host ports are deliberately uncommon (28080/24000/24001/23306/27700) so they
 # don't clash with anything else you have running (a local MySQL on 3306, a dev
@@ -21,13 +28,9 @@
 #   - front-end host port  -> back-end CORS_ORIGINS (browser origin)
 #   - back-end host port    -> front-end VITE_ROOT_URL (where the SPA calls the API)
 #
-# The values below are DEV-ONLY throwaway credentials. Real secrets are handled
-# via Coolify in deployed environments (see technology-and-infrastructure).
-#
-# Map tiles need real Ordnance Survey / Mapbox keys to render; with the
-# placeholder keys below the app and login work but the map won't draw. Set
-# VITE_OS_KEY / VITE_MAPBOX_TOKEN / VITE_GEOCODER_TOKEN below (or via your shell)
-# to see the map.
+# The values inlined below are DEV-ONLY throwaways (DB creds, dev token/secret).
+# Real secrets - map tile keys, SendGrid, analytics, PBS pipeline keys - are NOT
+# here; they live in docker.env, fetched from Bitwarden.
 
 name: land-explorer-dev
 
@@ -97,6 +100,11 @@ services:
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
     container_name: lx-be
+    # Real secrets (SENDGRID_API_KEY, MIXPANEL_TOKEN, ANALYTICS_PEPPER, ...) come
+    # from docker.env. required: true => `up` fails if the file is missing.
+    env_file:
+      - path: ./docker.env
+        required: true
     environment:
       NODE_ENV: development
       PORT: "4000"
@@ -151,6 +159,11 @@ services:
       args:
         NODE_VERSION: ${NODE_VERSION:-24}
     container_name: lx-pbs
+    # PBS pipeline secrets (GOV_API_KEY, OS_NGD_API_KEY, ...) come from docker.env.
+    # required: true => `up` fails if the file is missing.
+    env_file:
+      - path: ./docker.env
+        required: true
     environment:
       NODE_ENV: development
       PORT: "4000"
@@ -183,10 +196,12 @@ services:
         # The SPA calls the back-end cross-origin at this URL (baked in at build).
         # Must match the back-end's host port (24000).
         VITE_ROOT_URL: http://localhost:24000
-        # Placeholders - replace with real keys to render the map.
-        VITE_OS_KEY: ${VITE_OS_KEY:-placeholder}
-        VITE_GEOCODER_TOKEN: ${VITE_GEOCODER_TOKEN:-placeholder}
-        VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-placeholder}
+        # Map tile keys, required (the map won't render without them). These are
+        # build args, so they come from docker.env via --env-file. The ${VAR:?}
+        # form makes Compose abort with this message if they're unset.
+        VITE_OS_KEY: ${VITE_OS_KEY:?missing - download docker.env from Bitwarden and run with --env-file docker.env}
+        VITE_GEOCODER_TOKEN: ${VITE_GEOCODER_TOKEN:?missing - download docker.env from Bitwarden and run with --env-file docker.env}
+        VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:?missing - download docker.env from Bitwarden and run with --env-file docker.env}
     container_name: lx-fe
     ports:
       - "28080:80"

--- a/docker.env.example
+++ b/docker.env.example
@@ -1,0 +1,41 @@
+# Secrets for the local Docker stack (compose.all.yml).
+# See docs/containers.md for instructions
+
+# FE
+#VITE_ROOT_URL=http://localhost:4000
+#VITE_PAYMENTS_URL=<this is not currently used>
+#VITE_OS_KEY=<get this from the Ordnance Survey dashboard>
+#VITE_OS_PLACES_KEY=<get this from the Ordnance Survey dashboard>
+#VITE_GEOCODER_TOKEN=<get this from the Mapbox dashboard>
+#VITE_MAPBOX_TOKEN=<get this from the Mapbox dashboard>
+#VITE_MIXPANEL_TOKEN=<get this from the Mixpanel dashboard>
+#VITE_MIXPANEL_PEPPER=<random string - match this to the backend value>
+#VITE_USER_GUIDE_URL=https://digital-commons.gitbook.io/landexplorer-user-guide/functionality/quick-start-guide
+
+
+# BE
+#SENDGRID_API_KEY=
+#GLITCHTIP_KEY=
+# For Mixpanel analytics, this token and pepper needs to be set
+# Changing the pepper will mean that old user IDs and map IDs can't be correlated
+#MIXPANEL_TOKEN=<get this from the Mixpanel dashboard>
+#ANALYTICS_PEPPER=<use a random string>
+#DATABASE_HOST=127.0.0.1
+#DATABASE_USER=
+#DATABASE_PASSWORD=
+#DATABASE_NAME=
+#DATABASE_PORT=3306
+#BOUNDARY_SERVICE_URL=
+#BOUNDARY_SERVICE_SECRET=
+#PORT=4000
+#TOKEN_KEY=CHANGE_THIS_TO_SOMETHING_LONG_AND_RANDOM
+#TOKEN_EXPIRY_DAYS=365
+#BUTTONDOWN_API_KEY=
+
+
+# PBS
+#GOV_API_URL=
+#GOV_API_KEY=
+#OS_NGD_API_URL=
+#OS_NGD_API_KEY=
+#MAPBOX_GEOCODER_TOKEN=

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,0 +1,74 @@
+# Running LX in containers
+
+Land Explorer code is in 3 git repos that are built into 3 Docker images:
+
+- back-end - land-explorer-back-end - this repo - Node, Hapi, compiled to lib/
+- front-end - land-explorer-front-end - caddy serving the built Vite SPA
+- pbs - property-boundaries-service - Hapi ESM, compiled to dist/
+
+They depend on two stateful services:
+
+- mysql - two databases, land_explorer (back end) and property_boundaries (PBS)
+- meilisearch - full text search, used by PBS and the back end
+
+This documentation is about building and running through docker, see technology-and-infrastructure for details on how to deploy via Coolify.
+
+## Quick start - whole stack on your local dev machine
+
+compose.all.yml at the root of this repo bring up everything with one command, all three repos and throwaway mysql and meilisearch. The three repos need to be checked out side by side to run it then from land-explorer-back-end run:
+
+```
+docker compose -f compose.all.yml up --build
+```
+
+Open http://localhost:8080
+
+The services running when the containers come up are:
+
+| Port | Service |
+| 8080 | Caddy - front-end reverse proxy for end users |
+| 4000 | Back-end API |
+| 4001 | PBS API |
+| 3306 | MySQL |
+| 7700 | Meilisearch |
+
+The credentials in compose.all.yml are dev throwaways - the live (dev/staging/prod) secrets are injected by Coolify.
+
+### Seeing the map
+
+Tiles won't render without keys. Get those from bitwarden and run like this:
+
+```
+VITE_OS_KEY=... VITE_MAPBOX_TOKEN=... VITE_GEOCODER_TOKEN=... \
+    docker compose -f compose.all.yml up --build
+```
+
+### Reset
+
+MySQL and Meilisearch data is stored in named volumes (mysql_data and meilisearch_data) - to wipe and start clean:
+
+```
+docker compose -f compose.all.yml down -v
+```
+
+### Individual images
+
+Each repo has a Dockerfile. They are multi stage (Node then runtime stage) and they all require NODE_VERSION to be passed explicity. For example to build the front end:
+
+```
+docker build \
+--build-arg NODE_VERSION=24 \
+--build-arg CADDY_HOSTNAME=app.landexplorer.coop \
+--build-arg VITE_ROOT_URL=https://api.landexplorer.coop \
+--build-arg VITE_OS_KEY=... \
+--build-arg VITE_MAPBOX_TOKEN=... \
+--build-arg VITE_GEOCODER_TOKEN=... \
+-t lx-front-end land-explorer-front-end
+```
+### Runtime config
+
+Unlike the front end the BE and PBS read config from runtime env variables. The full list lives in .env.example
+
+### Database migrations
+
+The images run the app, not migrations. There is a back-end-migrate service that runs `npx sequelize-cli db:migrate` before the app starts.

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -75,6 +75,12 @@ You can also trigger it manually:
 curl 'http://localhost:24001/run-pipeline?secret=devsecret&startAtTask=ownerships'
 ```
 
+For just meilisearch you need to trigger it via:
+
+```
+curl 'http://localhost:24001/run-pipeline?secret=devsecret&startAtTask=updateProprietors&stopBeforeTask=downloadInspire'
+```
+
 Two issues:
 
 - It will take a **LONG TIME** - possibly several days and needs real GOV_API_* keys in docker.env - if you start it at updateProprietors instead it will re-index land_ownerships instead of starting from the beginning

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -21,16 +21,24 @@ compose.all.yml at the root of this repo bring up everything with one command, a
 docker compose -f compose.all.yml up --build
 ```
 
-Open http://localhost:8080
+You will see logs in the console. The first time starting up migrations will take several minutes.
 
-The services running when the containers come up are:
+Open LX at http://localhost:28080
 
-| Port | Service |
-| 8080 | Caddy - front-end reverse proxy for end users |
-| 4000 | Back-end API |
-| 4001 | PBS API |
-| 3306 | MySQL |
-| 7700 | Meilisearch |
+The host ports are deliberately uncommon so they don't clash with other things you might have running:
+
+| Host port | Service (container) | Container port |
+| --- | --- | --- |
+| 28080 | Caddy - front-end for end users (lx-fe) | 80 |
+| 24000 | Back-end API (lx-be) | 4000 |
+| 24001 | PBS API (lx-pbs) | 4000 |
+| 23306 | MySQL (lx-mysql) | 3306 |
+| 27700 | Meilisearch (lx-meilisearch) | 7700 |
+
+If you change the front-end or back-end host port, update the matching value:
+
+- the back-end's `CORS_ORIGINS` (the front-end's browser origin)
+- the front-end's `VITE_ROOT_URL` build arg (where the SPA calls the API).
 
 The credentials in compose.all.yml are dev throwaways - the live (dev/staging/prod) secrets are injected by Coolify.
 
@@ -71,4 +79,4 @@ Unlike the front end the BE and PBS read config from runtime env variables. The 
 
 ### Database migrations
 
-The images run the app, not migrations. There is a back-end-migrate service that runs `npx sequelize-cli db:migrate` before the app starts.
+The images run the app, not migrations. Two one-shot services, lx-be-migrate and lx-pbs-migrate, run `npx sequelize-cli db:migrate` (against the lx-be and lx-pbs runtime images) before the back end and pbs start. This is the same migrate path Coolify uses via its pre-deploy command.

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -48,6 +48,25 @@ If you change the front-end or back-end host port, update the matching value:
 
 The credentials inlined in compose.all.yml are dev throwaways. Real secrets - map keys, SendGrid, analytics, PBS pipeline keys - are in docker.env (from Bitwarden). The live secrets are injected by Coolify.
 
+### Reset
+
+MySQL and Meilisearch data is stored in named volumes (mysql_data and meilisearch_data) - to wipe the database and start clean drop the volumes:
+
+```
+docker compose --env-file docker.env  -f compose.all.yml down -v --remove-orphans
+docker compose --env-file docker.env -f compose.all.yml up --build
+```
+
+## Rebuild
+
+To rebuild, for example, just the back end, run:
+
+```
+docker compose --env-file docker.env -f compose.all.yml up --build lx-be
+```
+
+You can add `-d` to run in the background as well and use `docker logs` to inspect the logs.
+
 ### Env vars and secrets
 
 There are two kinds of config:
@@ -86,25 +105,6 @@ Two issues:
 - It will take a **LONG TIME** - possibly several days and needs real GOV_API_* keys in docker.env - if you start it at updateProprietors instead it will re-index land_ownerships instead of starting from the beginning
 - The downloadInspire task for the INSPIRE boundaries from https://use-land-property-data.service.gov.uk/datasets/inspire/download is failing - it is failing in the non-docker version - see https://github.com/DigitalCommons/property-boundaries-service/issues/45
 
-
-### Reset
-
-MySQL and Meilisearch data is stored in named volumes (mysql_data and meilisearch_data) - to wipe the database and start clean drop the volumes:
-
-```
-docker compose --env-file docker.env  -f compose.all.yml down -v
-docker compose --env-file docker.env -f compose.all.yml up --build
-```
-
-## Rebuild
-
-To rebuild, for example, just the back end, run:
-
-```
-docker compose --env-file docker.env -f compose.all.yml up --build lx-be
-```
-
-You can add `-d` to run in the background as well and use `docker logs` to inspect the logs.
 
 ### Individual images
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -57,6 +57,30 @@ There are two kinds of config:
 
 `.env.example` in each repo is the reference list of every variable and is what you copy to `.env` for *native* (non-Docker) dev - it is not read by the containers.
 
+### Populating property data and proprietor search
+
+When you start the containers fresh you will get an empty property_boundaries table and an empty Meilisearch index. Map and login work but Land Ownership layer and proprietor search return nothing until PBS pipeline runs.
+
+At some point we should add a small set of test data or the ability to copy from an existing database.
+
+To populate the data needed for these features run this optional one-shot docker service - it happens in lx-pbs and you can watch the logs to see progress:
+
+```
+docker compose --env-file docker.env -f compose.all.yml --profile seed up lx-pbs-seed
+```
+
+You can also trigger it manually:
+
+```
+curl 'http://localhost:24001/run-pipeline?secret=devsecret&startAtTask=ownerships'
+```
+
+Two issues:
+
+- It will take a **LONG TIME** - possibly several days and needs real GOV_API_* keys in docker.env - if you start it at updateProprietors instead it will re-index land_ownerships instead of starting from the beginning
+- The downloadInspire task for the INSPIRE boundaries from https://use-land-property-data.service.gov.uk/datasets/inspire/download is failing - it is failing in the non-docker version - see https://github.com/DigitalCommons/property-boundaries-service/issues/45
+
+
 ### Reset
 
 MySQL and Meilisearch data is stored in named volumes (mysql_data and meilisearch_data) - to wipe the database and start clean drop the volumes:

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -15,11 +15,17 @@ This documentation is about building and running through docker, see technology-
 
 ## Quick start - whole stack on your local dev machine
 
-compose.all.yml at the root of this repo bring up everything with one command, all three repos and throwaway mysql and meilisearch. The three repos need to be checked out side by side to run it then from land-explorer-back-end run:
+compose.all.yml at the root of this repo bring up everything with one command, all three repos and throwaway mysql and meilisearch. The three repos need to be checked out side by side to run it.
+
+First download the secrets file docker.env from Bitwarden (named Land Explorer docker.env) and put it in this repo's root - or if you don't have Bitwarden access edit the docker.env.example and rename it to docker.env
+
+Then from land-explorer-back-end run:
 
 ```
-docker compose -f compose.all.yml up --build
+docker compose --env-file docker.env -f compose.all.yml up --build
 ```
+
+`--env-file docker.env` is needed because the front-end's map keys are build args, which Compose only resolves from `--env-file` or the shell not from the env_file arg in the compose file.
 
 You will see logs in the console. The first time starting up migrations will take several minutes.
 
@@ -40,23 +46,24 @@ If you change the front-end or back-end host port, update the matching value:
 - the back-end's `CORS_ORIGINS` (the front-end's browser origin)
 - the front-end's `VITE_ROOT_URL` build arg (where the SPA calls the API).
 
-The credentials in compose.all.yml are dev throwaways - the live (dev/staging/prod) secrets are injected by Coolify.
+The credentials inlined in compose.all.yml are dev throwaways. Real secrets - map keys, SendGrid, analytics, PBS pipeline keys - are in docker.env (from Bitwarden). The live secrets are injected by Coolify.
 
-### Seeing the map
+### Env vars and secrets
 
-Tiles won't render without keys. Get those from bitwarden and run like this:
+There are two kinds of config:
 
-```
-VITE_OS_KEY=... VITE_MAPBOX_TOKEN=... VITE_GEOCODER_TOKEN=... \
-    docker compose -f compose.all.yml up --build
-```
+- dev throwaways - inlined in compose.all.yml (DB host/user/password, dev `TOKEN_KEY`, `devsecret`). Nothing to do.
+- real secrets - in `docker.env` (download from Bitwarden, see `docker.env.example`). The back-end and PBS load it at runtime via `env_file:`; the front-end map keys are build args fed by `--env-file docker.env`. Without keys the app and login work but the map won't render and emails won't send.
+
+`.env.example` in each repo is the reference list of every variable and is what you copy to `.env` for *native* (non-Docker) dev - it is not read by the containers.
 
 ### Reset
 
-MySQL and Meilisearch data is stored in named volumes (mysql_data and meilisearch_data) - to wipe and start clean:
+MySQL and Meilisearch data is stored in named volumes (mysql_data and meilisearch_data) - to wipe the database and start clean drop the volumes:
 
 ```
-docker compose -f compose.all.yml down -v
+docker compose --env-file docker.env  -f compose.all.yml down -v
+docker compose --env-file docker.env -f compose.all.yml up --build
 ```
 
 ### Individual images

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -71,8 +71,10 @@ docker compose --env-file docker.env -f compose.all.yml up --build
 To rebuild, for example, just the back end, run:
 
 ```
-docker compose --env-file docker.env -f compose.all.yml up -d --build lx-be
+docker compose --env-file docker.env -f compose.all.yml up --build lx-be
 ```
+
+You can add `-d` to run in the background as well and use `docker logs` to inspect the logs.
 
 ### Individual images
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -66,6 +66,14 @@ docker compose --env-file docker.env  -f compose.all.yml down -v
 docker compose --env-file docker.env -f compose.all.yml up --build
 ```
 
+## Rebuild
+
+To rebuild, for example, just the back end, run:
+
+```
+docker compose --env-file docker.env -f compose.all.yml up -d --build lx-be
+```
+
 ### Individual images
 
 Each repo has a Dockerfile. They are multi stage (Node then runtime stage) and they all require NODE_VERSION to be passed explicity. For example to build the front end:

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,19 @@
+/**
+ * Origins allowed to make cross-origin requests to the API and the websocket
+ * server. Prefer the explicit CORS_ORIGINS env var (comma-separated); fall back
+ * to the local dev front-end origin when running in development so local setups
+ * keep working with no extra config.
+ *
+ * In deployed environments (e.g. Coolify) the front-end is served from its own
+ * domain, so set CORS_ORIGINS, e.g.
+ *   CORS_ORIGINS=https://dev.cool.landexplorer.coop
+ */
+export function getCorsOrigins(): string[] {
+  return (
+    process.env.CORS_ORIGINS ??
+    (process.env.NODE_ENV === "development" ? "http://localhost:8080" : "")
+  )
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,14 +24,30 @@ function index(request: Request): string {
 }
 
 export const init = async function (): Promise<Server> {
+  // Origins allowed to make cross-origin requests to this API. Prefer the
+  // explicit CORS_ORIGINS env var (comma-separated); fall back to the local
+  // dev front-end origin when running in development so local setups keep
+  // working with no extra config.
+  const corsOrigins = (
+    process.env.CORS_ORIGINS ??
+    (process.env.NODE_ENV === "development" ? "http://localhost:8080" : "")
+  )
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
   server = Hapi.server({
     port: process.env.PORT || 4000,
     host: "0.0.0.0",
     debug: { log: ["error"], request: ["error"] },
-    // if we are running in development, allow requests from the expected localhost:8080 origin
+    // Allow cross-origin requests from the front-end origin(s). In local dev the
+    // front-end is at localhost:8080; in deployed environments (e.g. Coolify) the
+    // front-end is served from its own domain, so set CORS_ORIGINS to a
+    // comma-separated list of allowed origins, e.g.
+    //   CORS_ORIGINS=https://dev.cool.landexplorer.coop
     routes: {
-      cors: process.env.NODE_ENV === "development" && {
-        origin: ["http://localhost:8080"],
+      cors: corsOrigins.length > 0 && {
+        origin: corsOrigins,
         // Allow WebSocket connections
         additionalHeaders: ["authorization", "content-type"],
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { mapRoutes } from "./routes/map";
 import { dataGroupRoutes } from "./routes/datagroup";
 import { proprietorRoutes } from "./routes/proprietors";
 import { setupWebsockets } from "./websockets/server";
+import { getCorsOrigins } from "./cors";
 
 const AuthBearer = require("hapi-auth-bearer-token");
 const Inert = require("@hapi/inert");
@@ -24,17 +25,7 @@ function index(request: Request): string {
 }
 
 export const init = async function (): Promise<Server> {
-  // Origins allowed to make cross-origin requests to this API. Prefer the
-  // explicit CORS_ORIGINS env var (comma-separated); fall back to the local
-  // dev front-end origin when running in development so local setups keep
-  // working with no extra config.
-  const corsOrigins = (
-    process.env.CORS_ORIGINS ??
-    (process.env.NODE_ENV === "development" ? "http://localhost:8080" : "")
-  )
-    .split(",")
-    .map((origin) => origin.trim())
-    .filter(Boolean);
+  const corsOrigins = getCorsOrigins();
 
   server = Hapi.server({
     port: process.env.PORT || 4000,
@@ -48,8 +39,10 @@ export const init = async function (): Promise<Server> {
     routes: {
       cors: corsOrigins.length > 0 && {
         origin: corsOrigins,
-        // Allow WebSocket connections
-        additionalHeaders: ["authorization", "content-type"],
+        // Allow the headers the front-end actually sends
+        // x-session-id is added to every request as otherwise CORS preflight
+        // fails for authenticated calls
+        additionalHeaders: ["authorization", "content-type", "x-session-id"],
       },
     },
   });

--- a/src/websockets/server.ts
+++ b/src/websockets/server.ts
@@ -2,6 +2,7 @@ import { Socket, Server as SocketIOServer } from "socket.io";
 import { Server as HapiServer } from "@hapi/hapi";
 import { clearAllLocks, maybeUnlock, getUserWithLockOrNull } from "./locking";
 import jwt, { JwtPayload } from "jsonwebtoken";
+import { getCorsOrigins } from "../cors";
 
 /** The socket.io server object */
 export let io: SocketIOServer;
@@ -11,15 +12,13 @@ export const setupWebsockets = (server: HapiServer): void => {
   io?.close();
   clearAllLocks();
 
+  // Allow websocket (socket.io) connections from the same front-end origins
+  // the HTTP API allows (see src/cors.ts)
+  // An empty list imples no cross-origin config (same-origin only)
+  const corsOrigins = getCorsOrigins();
   io = new SocketIOServer(
     server.listener,
-    process.env.NODE_ENV === "development"
-      ? {
-          cors: {
-            origin: "http://localhost:8080",
-          },
-        }
-      : {}
+    corsOrigins.length > 0 ? { cors: { origin: corsOrigins } } : {}
   );
 
   io.on("connection", (socket) => {


### PR DESCRIPTION
#### What? Why?

Made LX run in docker containers. This is not intended to replace just running it locally but is required to get it running on coolify to replace the dev and prod servers with automatically managed and updated servers that should also produce versions for each PR.

See issue #92 

#### Code-specific details (for Reviewer)

I've created multi-stage dockerfiles for the BE, FE and PBS.

I added a compose.all.yml which is a one-command full stack (FE+BE+PBS+MySQL+Meilisearch). Migrations are run as one shot containers.

Secrets come in from docker.env - you can edit docker.env.example or get a copy from bitwarden with valid keys.

Because the docker containers use different hostnames and ports to communicate I added CORS_ORIGINS - the default behavior of allowing localhost:8080 for dev is still there.

Design doc: https://github.com/DigitalCommons/technology-and-infrastructure/issues/153

#### What should we test? (for QA)

- Install docker and docker-compose - https://docs.docker.com/compose/ and https://docs.docker.com/ if you don't have them (try docker-compose on the command line)
- Check out 93-containterise on be, fe and pbs in a directory next to each other
- Read docs/containers.md
- Follow the steps to run docker-compose and verify land explorer boots and runs at http://localhost:28080/
