### PR TITLE
Remove MEILISEARCH_ENABLED feature flag

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -22,4 +22,3 @@ GLITCHTIP_KEY=
 # For Mixpanel analytics, this token and pepper needs to be set
 MIXPANEL_TOKEN=
 ANALYTICS_PEPPER=test_analytics_pepper
-MEILISEARCH_ENABLED=true

--- a/docs/proprietors-endpoint.md
+++ b/docs/proprietors-endpoint.md
@@ -47,10 +47,6 @@ GET /api/proprietors?searchTerm=Acme&page=1&pageSize=10
 
 **500 Internal Server Error** - returned on unexpected errors from the PBS.
 
-## Feature flag
-
-Set `MEILISEARCH_ENABLED=true` in your `.env` to enable this endpoint. It is enabled by default in `.env.test`.
-
 ## Implementation
 
 | File | Role |

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,9 +76,7 @@ export const init = async function (): Promise<Server> {
   server.route(userRoutes);
   server.route(mapRoutes);
   server.route(dataGroupRoutes);
-  if (process.env.MEILISEARCH_ENABLED === "true") {
-    server.route(proprietorRoutes);
-  }
+  server.route(proprietorRoutes);
 
   // Log requests and response codes
   server.events.on("response", (request: any) => {
@@ -89,7 +87,7 @@ export const init = async function (): Promise<Server> {
         " " +
         request.path +
         " --> " +
-        request.response.statusCode
+        request.response.statusCode,
     );
   });
 


### PR DESCRIPTION
#### What? Why?
https://github.com/DigitalCommons/land-explorer/issues/47

Chore to clean up MEILISEARCH_ENABLED feature flag now that backsearch work has been released for over a month

#### What should we test? (for QA)
Test the backsearch functionality still works ok

#### Deployment notes
Remove MEILISEARCH_ENABLED from .env file