### PR TITLE
Task/analytics extra bits

### DIFF
--- a/docs/analytics-audit.md
+++ b/docs/analytics-audit.md
@@ -1,0 +1,172 @@
+# Backend Analytics Events Audit
+
+All analytics events are sent to Mixpanel via the EU endpoint (`api-eu.mixpanel.com`). IP geolocation is disabled. Events flow through one of two functions:
+
+- **`trackUserEvent`** - respects the user's analytics consent. With consent: uses a pseudonymous hashed user ID as `distinct_id` and includes `user_groups`. Without consent: uses a session UUID as `distinct_id`. 
+- **`trackUserMapEvent`** - wraps `trackUserEvent`. With consent: also includes a hashed `map_id`. Without consent: `map_id` is omitted entirely.
+
+When analtics consent is given, the `distinct_id` hash is SHA-256 of `userId + username + ANALYTICS_PEPPER` (server-side secret), truncated to 16 chars. The `map_id` hash is SHA-256 of `mapId + map.created_date + ANALYTICS_PEPPER`, truncated to 16 chars. Both are pseudonymous rather than anonymous.
+
+---
+
+## Events
+
+### `User_Register`
+**Trigger:** New user registers an account  
+**Source:** `src/routes/user.ts`  
+**Notes:** Fires before consent is possible. Uses a fresh random UUID (not stored) as `distinct_id` - genuinely anonymous, no PII.
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | random UUID | random UUID |
+| `sharedMaps` | boolean | boolean |
+| `user_groups` | — | — |
+
+---
+
+### `User_Feedback`
+**Trigger:** User submits the in-app feedback form  
+**Source:** `src/routes/user.ts`  
+**Notes:** Free-text answers are withheld for non-consenting users because the text is uniquely matchable to a `user_id` via the database, making it re-identifiable personal data.
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `question_use_case` | string | — |
+| `question_impact` | string | — |
+| `question_who_benefits` | string | — |
+| `question_improvements` | string | — |
+
+---
+
+### `User_ViewedGuide`
+**Trigger:** User views the user guide when prompted  
+**Source:** `src/routes/user.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `source` | string (entry point) | string (entry point) |
+
+---
+
+### `Map_FirstSave`
+**Trigger:** User saves a map for the first time  
+**Source:** `src/queries/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+| `drawings_count` | number | number |
+
+---
+
+### `Map_Open`
+**Trigger:** Map owner opens their map (not fired on first save)  
+**Source:** `src/routes/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+| `drawn_count` | number | number |
+
+---
+
+### `Map_SharedOpen`
+**Trigger:** A non-owner opens a map that has been shared with them  
+**Source:** `src/routes/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+| `drawn_count` | number | number |
+| `access` | `"Readonly"` or `"Edit"` | `"Readonly"` or `"Edit"` |
+
+---
+
+### `Map_Share`
+**Trigger:** Map owner shares their map with one or more users  
+**Source:** `src/queries/map.ts`  
+**Notes:** `sharedWith` entries are hashed user IDs for consenting recipients, `"NO_CONSENT"` for non-consenting registered recipients and `"PENDING_USER"` for unregistered recipients. This event is only fired if at least one new user is being granted access.
+
+| Field | Consenting (owner) | Non-consenting (owner) |
+|---|---|---|
+| `distinct_id` | hashed owner user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+| `sharedWith` | array of hashed IDs / `"NO_CONSENT"` / `"PENDING_USER"` | array of hashed IDs / `"NO_CONSENT"` / `"PENDING_USER"` |
+
+---
+
+### `Map_Export_Shapefile`
+**Trigger:** User exports their map as a shapefile  
+**Source:** `src/routes/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+
+---
+
+### `Map_Export_GeoJSON`
+**Trigger:** Map owner creates a public GeoJSON link for their map  
+**Source:** `src/routes/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+
+---
+
+### `Map_GeoJsonOpen`
+**Trigger:** An anonymous visitor opens a public map link (no login required)  
+**Source:** `src/routes/map.ts`  
+**Notes:** `userId` is `-1` (no real user). Consent is always false. `map_id` is never included.
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | — | session UUID |
+| `map_id` | — | — |
+
+---
+
+### `LandOwnership_Enable`
+**Trigger:** User enables or switches the land ownership layer on a map  
+**Source:** `src/queries/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `map_id` | hashed map ID | — |
+| `layer_id` | string (layer name) | string (layer name) |
+
+---
+
+### `LandOwnership_Backsearch`
+**Trigger:** User searches for properties by owner name  
+**Source:** `src/routes/map.ts`
+
+| Field | Consenting | Non-consenting |
+|---|---|---|
+| `distinct_id` | hashed user ID | session UUID |
+| `user_groups` | array of group names | — |
+| `properties_count` | number of results | number of results |
+
+---
+
+## Defined but unused
+
+`LandOwnership_SaveProperty` is declared in `src/instrument.ts` but never called anywhere in the codebase.

--- a/docs/analytics-audit.md
+++ b/docs/analytics-audit.md
@@ -137,7 +137,7 @@ When analtics consent is given, the `distinct_id` hash is SHA-256 of `userId + u
 
 | Field | Consenting | Non-consenting |
 |---|---|---|
-| `distinct_id` | — | session UUID |
+| `distinct_id` | — | — |
 | `map_id` | — | — |
 
 ---

--- a/docs/analytics-audit.md
+++ b/docs/analytics-audit.md
@@ -27,16 +27,16 @@ When analtics consent is given, the `distinct_id` hash is SHA-256 of `userId + u
 ### `User_Feedback`
 **Trigger:** User submits the in-app feedback form  
 **Source:** `src/routes/user.ts`  
-**Notes:** Free-text answers are withheld for non-consenting users because the text is uniquely matchable to a `user_id` via the database, making it re-identifiable personal data.
+**Notes:** `sessionId` is hardcoded to `"0"` rather than the real session ID, so feedback cannot be linked to a user's other session activity. Free-text answers are sent regardless of consent - the consent check in `trackUserEvent` only controls `distinct_id` and `user_groups`, not the payload.
 
 | Field | Consenting | Non-consenting |
 |---|---|---|
-| `distinct_id` | hashed user ID | session UUID |
+| `distinct_id` | hashed user ID | `"0"` |
 | `user_groups` | array of group names | — |
-| `question_use_case` | string | — |
-| `question_impact` | string | — |
-| `question_who_benefits` | string | — |
-| `question_improvements` | string | — |
+| `question_use_case` | string | string |
+| `question_impact` | string | string |
+| `question_who_benefits` | string | string |
+| `question_improvements` | string | string |
 
 ---
 

--- a/migrations/20260626120000-alter-user-analytics-consent-timestamps.js
+++ b/migrations/20260626120000-alter-user-analytics-consent-timestamps.js
@@ -1,0 +1,21 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE user
+        DROP COLUMN analytics_consent,
+        ADD analytics_consent_granted_at DATETIME DEFAULT NULL,
+        ADD analytics_consent_revoked_at DATETIME DEFAULT NULL;`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE user
+        DROP COLUMN analytics_consent_granted_at,
+        DROP COLUMN analytics_consent_revoked_at,
+        ADD analytics_consent BOOLEAN DEFAULT NULL;`,
+    );
+  },
+};

--- a/src/queries/database.ts
+++ b/src/queries/database.ts
@@ -47,7 +47,8 @@ const UserModel = sequelize.define(
     enabled: DataTypes.INTEGER,
     is_super_user: { type: DataTypes.BOOLEAN, allowNull: false },
     ask_for_feedback: DataTypes.BOOLEAN,
-    analytics_consent: DataTypes.BOOLEAN,
+    analytics_consent_granted_at: DataTypes.DATE,
+    analytics_consent_revoked_at: DataTypes.DATE,
     user_guide_prompt_seen: DataTypes.BOOLEAN,
 
     created_date: Sequelize.DATE,

--- a/src/queries/map.test.ts
+++ b/src/queries/map.test.ts
@@ -39,48 +39,91 @@ describe("trackUserMapEvent", () => {
       );
     });
 
-    it("calls trackUserEvent with consistent hashed mapId", async () => {
-      await trackUserMapEvent("test-session-id", testUserId, testMapId, Event.MAP.OPEN);
+    context("User has given analytics consent", () => {
+      beforeEach(() => {
+        sandbox.replace(
+          query,
+          "getUserById",
+          fake.resolves({
+            id: testUserId,
+            analytics_consent_granted_at: new Date("2024-01-01"),
+            analytics_consent_revoked_at: null,
+          })
+        );
+      });
 
-      expect(query.trackUserEvent.calledOnce).to.be.true;
-      const [, userId, event, data] = (query.trackUserEvent as any).firstCall
-        .args;
+      it("calls trackUserEvent with consistent hashed mapId", async () => {
+        await trackUserMapEvent("test-session-id", testUserId, testMapId, Event.MAP.OPEN);
 
-      expect(userId).to.equal(testUserId);
-      expect(event).to.equal(Event.MAP.OPEN);
-      expect(data.map_id).to.equal("0936b464a63bf05d"); // precomputed hash
-    });
+        expect(query.trackUserEvent.calledOnce).to.be.true;
+        const [, userId, event, data] = (query.trackUserEvent as any).firstCall.args;
 
-    it("merges additional data with hashed mapId", async () => {
-      const additionalData = { drawn_count: 5, access: "Readonly" };
+        expect(userId).to.equal(testUserId);
+        expect(event).to.equal(Event.MAP.OPEN);
+        expect(data.map_id).to.equal("0936b464a63bf05d"); // precomputed hash
+      });
 
-      await trackUserMapEvent(
-        "test-session-id",
-        testUserId,
-        testMapId,
-        Event.MAP.SHARED_OPEN,
-        additionalData
-      );
+      it("merges additional data with hashed mapId", async () => {
+        const additionalData = { drawn_count: 5, access: "Readonly" };
 
-      const [, , , data] = (query.trackUserEvent as any).firstCall.args;
+        await trackUserMapEvent(
+          "test-session-id",
+          testUserId,
+          testMapId,
+          Event.MAP.SHARED_OPEN,
+          additionalData
+        );
 
-      expect(data).to.deep.equal({
-        drawn_count: 5,
-        access: "Readonly",
-        map_id: data.map_id, // just verify it exists
+        const [, , , data] = (query.trackUserEvent as any).firstCall.args;
+
+        expect(data).to.deep.equal({
+          drawn_count: 5,
+          access: "Readonly",
+          map_id: data.map_id, // just verify it exists
+        });
+      });
+
+      it("produces different hash for different mapId", async () => {
+        await trackUserMapEvent("test-session-id", testUserId, testMapId + 1, Event.MAP.OPEN);
+        const [, , , data] = (query.trackUserEvent as any).firstCall.args;
+        expect(data.map_id).to.not.equal("0936b464a63bf05d");
       });
     });
 
-    it("produces different hash for different mapId", async () => {
-      await trackUserMapEvent("test-session-id", testUserId, testMapId + 1, Event.MAP.OPEN);
-      const [, , , data] = (query.trackUserEvent as any).firstCall.args;
-      expect(data.map_id).to.not.equal("0936b464a63bf05d");
+    context("User has not given analytics consent", () => {
+      beforeEach(() => {
+        sandbox.replace(
+          query,
+          "getUserById",
+          fake.resolves({
+            id: testUserId,
+            analytics_consent_granted_at: null,
+            analytics_consent_revoked_at: new Date("2024-01-01"),
+          })
+        );
+      });
+
+      it("does not include map_id in the event data", async () => {
+        await trackUserMapEvent("test-session-id", testUserId, testMapId, Event.MAP.OPEN);
+
+        const [, , , data] = (query.trackUserEvent as any).firstCall.args;
+        expect(data).to.not.have.property("map_id");
+      });
     });
   });
 
   context("Map doesn't exist", () => {
     beforeEach(() => {
       sandbox.replace(Model.Map, "findOne", fake.resolves(null));
+      sandbox.replace(
+        query,
+        "getUserById",
+        fake.resolves({
+          id: testUserId,
+          analytics_consent_granted_at: new Date("2024-01-01"),
+          analytics_consent_revoked_at: null,
+        })
+      );
     });
 
     it("uses MAP_NOT_FOUND as hashed mapId", async () => {
@@ -131,6 +174,15 @@ describe("compareMapDataChangesAndSendAnalytics", () => {
       })
     );
     sandbox.replace(query, "trackUserEvent", fake.resolves(null));
+    sandbox.replace(
+      query,
+      "getUserById",
+      fake.resolves({
+        id: testUserId,
+        analytics_consent_granted_at: new Date("2024-01-01"),
+        analytics_consent_revoked_at: null,
+      })
+    );
   });
 
   afterEach(() => {

--- a/src/queries/map.ts
+++ b/src/queries/map.ts
@@ -15,9 +15,10 @@ import {
 import { Op } from "sequelize";
 import { createHash } from "node:crypto";
 import { v4 as uuidv4 } from "uuid";
-import { getUserByEmail, hashUserId, trackUserEvent } from "./query";
+import { getUserByEmail, getUserById, hashUserId, trackUserEvent } from "./query";
 import * as mailer from "./mails";
 import { Event, EventName } from "../instrument";
+import { computeAnalyticsConsent } from "../userAnalyticsConsent";
 import * as Sentry from "@sentry/node";
 import { atomizeChangeset, diff } from "json-diff-ts";
 
@@ -58,10 +59,11 @@ export const trackUserMapEvent = async (
   event: EventName,
   data?: any,
 ) => {
-  const mapIdHash = await hashMapId(mapId);
+  const user = await getUserById(userId);
+  const mapIdHash = user && computeAnalyticsConsent(user) ? await hashMapId(mapId) : undefined;
   await trackUserEvent(sessionId, userId, event, {
     ...data,
-    map_id: mapIdHash,
+    ...(mapIdHash && { map_id: mapIdHash }),
   });
 };
 
@@ -593,8 +595,6 @@ export const createMap = async (
     false,
   );
 
-  console.log(`Created map ${newMap.id} with name ${name}`);
-
   trackUserMapEvent(sessionId, userId, newMap.id, Event.MAP.FIRST_SAVE, {
     // TODO: when we save properties, include this as properties_count
     drawings_count: markers.length + polygonsAndLines.length,
@@ -643,8 +643,6 @@ export const updateMap = async (
   name: string,
   data: SaveMapData,
 ) => {
-  console.log(`User ${userId} updating map ${mapId}`);
-
   if (data.markers.markers) {
     await bulkCreateUpdateAndDeleteMarkers(mapId, data.markers.markers, true);
   }
@@ -986,7 +984,9 @@ export const grantMapAccessByEmails = async (
           domain,
         );
       }
-      sharedWithAnalyticsData.push(await hashUserId(user));
+      sharedWithAnalyticsData.push(
+        computeAnalyticsConsent(user) ? await hashUserId(user) : "NO_CONSENT",
+      );
     } else {
       await PendingUserMap.create({
         map_id: mapId,

--- a/src/queries/query.test.ts
+++ b/src/queries/query.test.ts
@@ -451,13 +451,13 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
       );
 
       expect(trackRawEventSpy.calledOnce).to.be.true;
       const [event, data] = trackRawEventSpy.firstCall.args;
 
-      expect(event).to.equal("User_Register");
+      expect(event).to.equal("User_ViewedGuide");
       expect(data.distinct_id).to.equal("99a70b2e9c66404d");
     });
 
@@ -467,7 +467,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
         additionalData,
       );
 
@@ -483,7 +483,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId + 1,
-        "User_Register",
+        "User_ViewedGuide",
       );
       const [, data] = trackRawEventSpy.firstCall.args;
       expect(data.distinct_id).to.not.equal("99a70b2e9c66404d");
@@ -508,7 +508,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
       );
 
       expect(trackRawEventSpy.calledOnce).to.be.true;
@@ -520,7 +520,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
       );
 
       const [, data] = trackRawEventSpy.firstCall.args;
@@ -546,7 +546,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
       );
 
       const [, data] = trackRawEventSpy.firstCall.args;
@@ -572,7 +572,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
       );
 
       const [, data] = trackRawEventSpy.firstCall.args;
@@ -600,7 +600,7 @@ describe("trackUserEvent", () => {
         await query.trackUserEvent(
           "test-session-id",
           testUserId,
-          "User_Register",
+          "User_ViewedGuide",
         );
 
         expect(trackRawEventSpy.calledOnce).to.be.true;
@@ -612,7 +612,7 @@ describe("trackUserEvent", () => {
         await query.trackUserEvent(
           "test-session-id",
           testUserId,
-          "User_Register",
+          "User_ViewedGuide",
         );
 
         const [, data] = trackRawEventSpy.firstCall.args;
@@ -630,7 +630,7 @@ describe("trackUserEvent", () => {
       await query.trackUserEvent(
         "test-session-id",
         testUserId,
-        "User_Register",
+        "User_ViewedGuide",
       );
       const [, data] = trackRawEventSpy.firstCall.args;
       expect(data.distinct_id).to.equal("USER_NOT_FOUND");

--- a/src/queries/query.test.ts
+++ b/src/queries/query.test.ts
@@ -442,7 +442,8 @@ describe("trackUserEvent", () => {
       sandbox.stub(User, "findOne").callsFake(async (options: any) => ({
         id: options?.where?.id ?? testUserId,
         created_date: testUserCreatedDate,
-        analytics_consent: true,
+        analytics_consent_granted_at: new Date("2024-01-01"),
+        analytics_consent_revoked_at: null,
       }));
     });
 
@@ -497,7 +498,8 @@ describe("trackUserEvent", () => {
         fake.resolves({
           id: testUserId,
           created_date: testUserCreatedDate,
-          analytics_consent: false,
+          analytics_consent_granted_at: null,
+          analytics_consent_revoked_at: new Date("2024-01-01"),
         }),
       );
     });
@@ -526,6 +528,58 @@ describe("trackUserEvent", () => {
     });
   });
 
+  context("User exists with granted_at more recent than revoked_at", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        User,
+        "findOne",
+        fake.resolves({
+          id: testUserId,
+          created_date: testUserCreatedDate,
+          analytics_consent_granted_at: new Date("2024-06-01"),
+          analytics_consent_revoked_at: new Date("2024-01-01"),
+        }),
+      );
+    });
+
+    it("uses hashed userID as distinct_id", async () => {
+      await query.trackUserEvent(
+        "test-session-id",
+        testUserId,
+        "User_Register",
+      );
+
+      const [, data] = trackRawEventSpy.firstCall.args;
+      expect(data.distinct_id).to.equal("99a70b2e9c66404d");
+    });
+  });
+
+  context("User exists with revoked_at more recent than granted_at", () => {
+    beforeEach(() => {
+      sandbox.replace(
+        User,
+        "findOne",
+        fake.resolves({
+          id: testUserId,
+          created_date: testUserCreatedDate,
+          analytics_consent_granted_at: new Date("2024-01-01"),
+          analytics_consent_revoked_at: new Date("2024-06-01"),
+        }),
+      );
+    });
+
+    it("uses sessionId as distinct_id", async () => {
+      await query.trackUserEvent(
+        "test-session-id",
+        testUserId,
+        "User_Register",
+      );
+
+      const [, data] = trackRawEventSpy.firstCall.args;
+      expect(data.distinct_id).to.equal("test-session-id");
+    });
+  });
+
   context(
     "User exists with analytics_consent null (pre-migration existing user)",
     () => {
@@ -536,7 +590,8 @@ describe("trackUserEvent", () => {
           fake.resolves({
             id: testUserId,
             created_date: testUserCreatedDate,
-            analytics_consent: null,
+            analytics_consent_granted_at: null,
+            analytics_consent_revoked_at: null,
           }),
         );
       });

--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -235,9 +235,7 @@ export const trackUserEvent = async (
   let analyticsUserId = sessionId; // default to sessionId if we don't have consent to use the hashed user ID
   const user = await getUserById(userId);
   if (!user) {
-    console.error(
-      `User with ID ${userId} not found for tracking event ${event}`,
-    );
+    console.error(`User with not found for tracking event ${event}`);
     analyticsUserId = "USER_NOT_FOUND";
   }
   let analyticsConsent = computeAnalyticsConsent(user) ?? false;

--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -236,7 +236,8 @@ export const trackUserEvent = async (
   const user = await getUserById(userId);
   if (!user) {
     console.error(`User with not found for tracking event ${event}`);
-    analyticsUserId = "USER_NOT_FOUND";
+    trackRawEvent(event, { ...data, distinct_id: "USER_NOT_FOUND" });
+    return;
   }
   let analyticsConsent = computeAnalyticsConsent(user) ?? false;
     

--- a/src/queries/query.ts
+++ b/src/queries/query.ts
@@ -21,6 +21,7 @@ import { createHash } from "node:crypto";
 import axios from "axios";
 import { Op, QueryTypes } from "sequelize";
 import { EventName, trackRawEvent } from "../instrument";
+import { computeAnalyticsConsent } from "../userAnalyticsConsent";
 
 export const getUserById = async (id: number): Promise<typeof User | null> => {
   return await User.findOne({ where: { id } });
@@ -239,8 +240,8 @@ export const trackUserEvent = async (
     );
     analyticsUserId = "USER_NOT_FOUND";
   }
-  let analyticsConsent = user?.analytics_consent ?? false; // default to false if null/undefined
-
+  let analyticsConsent = computeAnalyticsConsent(user) ?? false;
+    
   if (analyticsConsent) {
     analyticsUserId = await hashUserId(user);
     // Include data on which user groups the user is a member of

--- a/src/routes/map.test.ts
+++ b/src/routes/map.test.ts
@@ -36,6 +36,7 @@ describe("GET /api/user/maps & GET/api/user/map/:eid", () => {
   beforeEach(async () => {
     server = await init();
     sandbox.replace(query, "trackUserEvent", fake.resolves(null));
+    sandbox.replace(query, "getUserById", fake.resolves(null));
   });
 
   afterEach(async () => {

--- a/src/routes/map.ts
+++ b/src/routes/map.ts
@@ -843,7 +843,6 @@ async function searchOwnership(
   const titles = await searchOwner(proprietorName);
 
   trackUserEvent(sessionId, user_id, Event.LAND_OWNERSHIP.BACKSEARCH, {
-    proprietor_name: proprietorName,
     properties_count: titles.length,
   });
 

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "chai";
 // Sinon provides mocks, spies, stubs, etc. We use them to replace and control the behaviour of code
 // that is external to our test unit, or to verify how out test unit interfaces with external code.
-import { assert, createSandbox, fake, SinonSpy } from "sinon";
+import { assert, createSandbox, fake, match, SinonSpy } from "sinon";
 import { Server } from "@hapi/hapi";
 import { init } from "../server";
 
@@ -374,7 +374,8 @@ describe("GET /api/user/details", () => {
           username: "douglas.quaid@yahoomail.com",
           first_name: "Douglas",
           last_name: "Quaid",
-          analytics_consent: true,
+          analytics_consent_granted_at: new Date("2024-01-01"),
+          analytics_consent_revoked_at: null,
         }),
       );
 
@@ -397,7 +398,56 @@ describe("GET /api/user/details", () => {
           username: "douglas.quaid@yahoomail.com",
           first_name: "Douglas",
           last_name: "Quaid",
-          analytics_consent: false,
+          analytics_consent_granted_at: null,
+          analytics_consent_revoked_at: new Date("2024-01-01"),
+        }),
+      );
+
+      const res = await server.inject({
+        method: "GET",
+        url: "/api/user/details",
+        auth: { strategy: "simple", credentials: { user_id: testUserId } },
+      });
+
+      expect(res.statusCode).to.equal(200);
+      expect((res.result as any).analyticsConsent).to.equal(false);
+    });
+
+    it("returns analyticsConsent: true when granted_at is more recent than revoked_at", async () => {
+      sandbox.replace(
+        Model.User,
+        "findOne",
+        fake.resolves({
+          id: testUserId,
+          username: "douglas.quaid@yahoomail.com",
+          first_name: "Douglas",
+          last_name: "Quaid",
+          analytics_consent_granted_at: new Date("2024-06-01"),
+          analytics_consent_revoked_at: new Date("2024-01-01"),
+        }),
+      );
+
+      const res = await server.inject({
+        method: "GET",
+        url: "/api/user/details",
+        auth: { strategy: "simple", credentials: { user_id: testUserId } },
+      });
+
+      expect(res.statusCode).to.equal(200);
+      expect((res.result as any).analyticsConsent).to.equal(true);
+    });
+
+    it("returns analyticsConsent: false when revoked_at is more recent than granted_at", async () => {
+      sandbox.replace(
+        Model.User,
+        "findOne",
+        fake.resolves({
+          id: testUserId,
+          username: "douglas.quaid@yahoomail.com",
+          first_name: "Douglas",
+          last_name: "Quaid",
+          analytics_consent_granted_at: new Date("2024-01-01"),
+          analytics_consent_revoked_at: new Date("2024-06-01"),
         }),
       );
 
@@ -420,7 +470,8 @@ describe("GET /api/user/details", () => {
           username: "douglas.quaid@yahoomail.com",
           first_name: "Douglas",
           last_name: "Quaid",
-          analytics_consent: null,
+          analytics_consent_granted_at: null,
+          analytics_consent_revoked_at: null,
         }),
       );
 
@@ -461,7 +512,7 @@ describe("POST /api/user/analytics-consent", () => {
     expect(res.statusCode).to.equal(200);
     assert.calledOnceWithMatch(
       fakeUserUpdate,
-      { analytics_consent: true },
+      { analytics_consent_granted_at: match.instanceOf(Date) },
       { where: { id: testUserId } },
     );
   });
@@ -477,7 +528,7 @@ describe("POST /api/user/analytics-consent", () => {
     expect(res.statusCode).to.equal(200);
     assert.calledOnceWithMatch(
       fakeUserUpdate,
-      { analytics_consent: false },
+      { analytics_consent_revoked_at: match.instanceOf(Date) },
       { where: { id: testUserId } },
     );
   });

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -363,25 +363,16 @@ async function userFeedback(
   );
 
   const userId = request.auth.credentials.user_id;
-  const { "x-session-id": sessionId } = request.headers;
 
-  await User.update(
-    { ask_for_feedback: false },
-    { where: { id: userId } },
-  );
+  await User.update({ ask_for_feedback: false }, { where: { id: userId } });
 
-  const user = await getUserById(userId);
-  const feedbackPayload =
-    user && computeAnalyticsConsent(user)
-      ? {
-          question_use_case,
-          question_impact,
-          question_who_benefits,
-          question_improvements,
-        }
-      : {};
-
-  trackUserEvent(sessionId, userId, Event.USER.FEEDBACK, feedbackPayload);
+  // we intentionally don't pass the sessionId for this event so that the user feedback can't be used to determine the user that links to a sessionId
+  trackUserEvent("0", userId, Event.USER.FEEDBACK, {
+    question_use_case,
+    question_impact,
+    question_who_benefits,
+    question_improvements,
+  });
 
   return h.response(userFeedback).code(200);
 }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -26,6 +26,7 @@ import {
   UpdateAnalyticsConsentRequest,
   UpdateUserGuidePromptSeenRequest,
 } from "./user.types";
+import { computeAnalyticsConsent } from "../userAnalyticsConsent";
 
 const RESET_PASSWORD_EXPIRY_HOURS = 24;
 
@@ -168,7 +169,7 @@ async function getAuthUserDetails(
     phone: user.phone ?? "",
     council_id: user.council_id ?? 0,
     is_super_user: user.is_super_user ?? 0,
-    analyticsConsent: user.analytics_consent,
+    analyticsConsent: computeAnalyticsConsent(user),
     userGuidePromptSeen: user.user_guide_prompt_seen ?? false,
   });
 }
@@ -361,28 +362,20 @@ async function userFeedback(
     request.auth.credentials.user_id,
   );
 
+  const userId = request.auth.credentials.user_id;
   const { "x-session-id": sessionId } = request.headers;
 
   await User.update(
     { ask_for_feedback: false },
-    {
-      where: {
-        id: request.auth.credentials.user_id,
-      },
-    },
+    { where: { id: userId } },
   );
 
-  trackUserEvent(
-    sessionId,
-    request.auth.credentials.user_id,
-    Event.USER.FEEDBACK,
-    {
-      question_use_case,
-      question_impact,
-      question_who_benefits,
-      question_improvements,
-    },
-  );
+  const user = await getUserById(userId);
+  const feedbackPayload = computeAnalyticsConsent(user)
+    ? { question_use_case, question_impact, question_who_benefits, question_improvements }
+    : {};
+
+  trackUserEvent(sessionId, userId, Event.USER.FEEDBACK, feedbackPayload);
 
   return h.response(userFeedback).code(200);
 }
@@ -455,7 +448,9 @@ async function updateAnalyticsConsent(
   h: ResponseToolkit,
 ): Promise<ResponseObject> {
   await User.update(
-    { analytics_consent: request.payload.analyticsConsent },
+    request.payload.analyticsConsent
+      ? { analytics_consent_granted_at: new Date() }
+      : { analytics_consent_revoked_at: new Date() },
     { where: { id: request.auth.credentials.user_id } },
   );
 

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -371,9 +371,15 @@ async function userFeedback(
   );
 
   const user = await getUserById(userId);
-  const feedbackPayload = computeAnalyticsConsent(user)
-    ? { question_use_case, question_impact, question_who_benefits, question_improvements }
-    : {};
+  const feedbackPayload =
+    user && computeAnalyticsConsent(user)
+      ? {
+          question_use_case,
+          question_impact,
+          question_who_benefits,
+          question_improvements,
+        }
+      : {};
 
   trackUserEvent(sessionId, userId, Event.USER.FEEDBACK, feedbackPayload);
 

--- a/src/userAnalyticsConsent.ts
+++ b/src/userAnalyticsConsent.ts
@@ -1,0 +1,26 @@
+import { User } from "./queries/database";
+
+export function computeAnalyticsConsent(user: typeof User): boolean | null {
+  // User has never granted or denied consent
+  if (
+    user.analytics_consent_granted_at == null &&
+    user.analytics_consent_revoked_at == null
+  ) {
+    return null;
+  }
+
+  if (user.analytics_consent_granted_at !== null) {
+    // User has granted consent and never denied consent
+    if (user.analytics_consent_revoked_at == null) {
+      return true;
+    }
+    // User has granted consent at a later date than it was last denied
+    if (user.analytics_consent_granted_at > user.analytics_consent_revoked_at) {
+      return true;
+    }
+    // User has denied consent at a later date than it was last granted
+    return false;
+  }
+  // user has never granted consent
+  return false;
+}

--- a/src/websockets/server.ts
+++ b/src/websockets/server.ts
@@ -39,21 +39,21 @@ export const setupWebsockets = (server: HapiServer): void => {
       throw err;
     }
 
-    console.log("User websocket connected", socket.data.userId);
+    console.log("User websocket connected");
 
     socket.on("disconnecting", () => {
-      console.log("User websocket disconnecting", socket.data.userId);
+      console.log("User websocket disconnecting");
       leaveAllMaps(socket);
     });
 
     socket.on("currentMap", async (mapId) => {
       if (mapId === null) {
         // null map id means a new untitled map was opened
-        console.log(`User ${socket.data.userId} opened a new untitled map`);
+        console.log(`User opened a new untitled map`);
         leaveAllMaps(socket);
       } else {
         if (getCurrentMapId(socket) != mapId) {
-          console.log(`User ${socket.data.userId} opened map ${mapId}`);
+          console.log(`User opened map`);
           leaveAllMaps(socket);
           socket.join(`${mapId}`);
         }


### PR DESCRIPTION
#### What? Why?
https://github.com/DigitalCommons/land-explorer/issues/29

This is a follow up PR for the analytics opt in flow to address Rohit's comments on the PR

#### Code-specific details (for Reviewer)

I have done the following:
- Changed the analytics consent from a boolean to 2 dates - consent_at and consent_revoked. After reading more about this having dates is better than a simple boolean and it was a straight forward change to make.
- Removed backend logging containing userId or any ids that could allow us to link an analytics event back to a user. I don't think this is a long term solution as we will need to log this info in some scenarios but it is an ok fix for now because there was only a small handful of these logs. I think we need to have a look at logging in Land Explorer and when we do, we will need to consider the impact on analytics anonymity.
- Removed the proprietor name from the backsearch event to help protect anonymity.
- I found another event that was hashing the mapId - this can be linked back to a user so I've added a guard so that if the user hasn't consented we no longer send this info (to keep anonymity).
- The `user_feedback` event sends some free text fields to analytics. If the user hasn't consented, the safest option is to not send the sessionID to analytics as the free text data could be linked back to the user. So we now only send the distinct_id when the user has consented to analytics otherwise we send 0 as the distinct_id.
- I found an analytics event that was recording the hashed user ids that a map was shared with. We shouldn't do this unless we have consent from those users so I have put a guard so that if the user hasn't consented, we don't send their hashed user id to analytics.
- I've added a document that audits all the different backend analytics events and what they send for consenting and non-consenting users

#### Deployment notes
None